### PR TITLE
Rename RayHitInfo to RayCollision

### DIFF
--- a/lib/raylib-zig.zig
+++ b/lib/raylib-zig.zig
@@ -323,10 +323,10 @@ pub const Ray = extern struct {
     direction: Vector3,
 };
 
-pub const RayHitInfo = extern struct {
+pub const RayCollision = extern struct {
     hit: bool,
     distance: f32,
-    position: Vector3,
+    point: Vector3,
     normal: Vector3,
 };
 


### PR DESCRIPTION
This struct was renamed in raylib 4.0.0: https://github.com/raysan5/raylib/commit/1c5de9721a8c9b9543044b461d4a9480c1d25b43