### PR TITLE
Update raylib to work with Zig >=0.10

### DIFF
--- a/lib.zig
+++ b/lib.zig
@@ -7,7 +7,7 @@ var ran_git = false;
 const srcdir = getSrcDir();
 
 fn getSrcDir() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse ".";
+    return std.fs.path.dirname(@src().file).?;
 }
 
 pub fn link(exe: *LibExeObjStep, system_lib: bool) void {


### PR DESCRIPTION
The updated raylib isn't an official raylib release. (it says 4.5-dev)