### PR TITLE
zig 0.11 package  support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .raylib = .{
-            .url = "https://github.com/raysan5/raylib/archive/ad2338b994785c887528c91a843d6720cac2c2b0.tar.gz",
-            .hash = "122003990d16146cfb85e04e0557f41b54e81bae635fa4379f3a597ed5fb7716ee53",
+            .url = "https://github.com/raysan5/raylib/archive/d3058fe58972b80684591237c6358104f9e28ba0.tar.gz",
+            .hash = "1220e120610addc41349bcf085e818591e3397485ef304f0103d6f11c09ec9d81c8c",
         },
     },
 }

--- a/lib/raylib-zig-math-ext.zig
+++ b/lib/raylib-zig-math-ext.zig
@@ -1,6 +1,6 @@
 // raylib-zig (c) Nikolas Wipper 2023
 
-const rl = @import("raylib-zig.zig");
+const rl = @import("raylib-zig");
 const rlm = @import("raylib-zig-math.zig");
 
 pub extern "c" fn Clamp(value: f32, min: f32, max: f32) f32;

--- a/lib/raylib-zig-math.zig
+++ b/lib/raylib-zig-math.zig
@@ -1,6 +1,6 @@
 // raylib-zig (c) Nikolas Wipper 2023
 
-const rl = @import("raylib-zig.zig");
+const rl = @import("raylib-zig");
 const cdef = @import("raylib-zig-math-ext.zig");
 const std = @import("std");
 


### PR DESCRIPTION
- Updated the `build.zig` to expose the `raylib-zig` and `raylib-zig-math` modules.
- Fixed the issue with recurrent imports `file exists in multiple modules`.
- Updated `build.zig.zon` raylib dependency hash to latest commit so that it would work with zig 0.11. 