### PR TITLE
Lock the cursor to the window for first person camera

### DIFF
--- a/examples/core/3d_camera_first_person.zig
+++ b/examples/core/3d_camera_first_person.zig
@@ -40,8 +40,8 @@ pub fn main() anyerror!void {
         );
     }
 
+    rl.disableCursor(); // Limit cursor to relative movement inside the window
     rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
-    rl.disableCursor(); // Lock the cursor to the window
     //--------------------------------------------------------------------------------------
 
     // Main game loop

--- a/examples/core/3d_camera_first_person.zig
+++ b/examples/core/3d_camera_first_person.zig
@@ -41,6 +41,7 @@ pub fn main() anyerror!void {
     }
 
     rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    rl.disableCursor(); // Lock the cursor to the window
     //--------------------------------------------------------------------------------------
 
     // Main game loop


### PR DESCRIPTION
Tiny update to make the 3d first person camera more usable, otherwise when turning the cursor escapes the window. 