### PR TITLE
fix project_setup.sh for zig version 0.12.0-dev.1849+bb0f7d55e

### DIFF
--- a/project_setup.sh
+++ b/project_setup.sh
@@ -15,8 +15,8 @@ const rl = @import("raylib-zig/build.zig");
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    var raylib = rl.getModule(b, "raylib-zig");
-    var raylib_math = rl.math.getModule(b, "raylib-zig");
+    const raylib = rl.getModule(b, "raylib-zig");
+    const raylib_math = rl.math.getModule(b, "raylib-zig");
     //web exports are completely separate
     if (target.getOsTag() == .emscripten) {
         const exe_lib = rl.compileForEmscripten(b, "'$PROJECT_NAME'", "src/main.zig", target, optimize);


### PR DESCRIPTION
This is a fix for the following issue.  It should not affect 0.11.0 compatibility.

```console
$ zig version
0.12.0-dev.1849+bb0f7d55e
$ git clone git@github.com:Not-Nik/raylib-zig.git
Cloning into 'raylib-zig'...
remote: Enumerating objects: 1314, done.
remote: Counting objects: 100% (330/330), done.
remote: Compressing objects: 100% (119/119), done.
remote: Total 1314 (delta 262), reused 243 (delta 211), pack-reused 984
Receiving objects: 100% (1314/1314), 728.80 KiB | 766.00 KiB/s, done.
Resolving deltas: 100% (813/813), done.
$ cd raylib-zig/
$ ./project_setup.sh raylib-demo
generating project files...
cloning raylib-zig inside of project...
Cloning into 'raylib-zig'...
done.
$ cd raylib-demo/
$ ls
build.zig  build.zig.zon  raylib-zig  src
$ zig build run
/tmp/raylib-zig/raylib-demo/build.zig:8:9: error: local variable is never mutated
    var raylib_math = rl.math.getModule(b, "raylib-zig");
        ^~~~~~~~~~~
/tmp/raylib-zig/raylib-demo/build.zig:8:9: note: consider using 'const'
/tmp/raylib-zig/raylib-demo/build.zig:7:9: error: local variable is never mutated
    var raylib = rl.getModule(b, "raylib-zig");
        ^~~~~~
/tmp/raylib-zig/raylib-demo/build.zig:7:9: note: consider using 'const'
```