### PR TITLE
fixed pointer cast that discards const qualifier

### DIFF
--- a/lib/raylib-zig-ext.zig
+++ b/lib/raylib-zig-ext.zig
@@ -207,7 +207,7 @@ pub extern "c" fn DrawPixelV(position: rl.Vector2, color: rl.Color) void;
 pub extern "c" fn DrawLine(startPosX: c_int, startPosY: c_int, endPosX: c_int, endPosY: c_int, color: rl.Color) void;
 pub extern "c" fn DrawLineV(startPos: rl.Vector2, endPos: rl.Vector2, color: rl.Color) void;
 pub extern "c" fn DrawLineEx(startPos: rl.Vector2, endPos: rl.Vector2, thick: f32, color: rl.Color) void;
-pub extern "c" fn DrawLineStrip(points: [*c]const rl.Vector2, pointCount: c_int, color: rl.Color) void;
+pub extern "c" fn DrawLineStrip(points: [*c]rl.Vector2, pointCount: c_int, color: rl.Color) void;
 pub extern "c" fn DrawLineBezier(startPos: rl.Vector2, endPos: rl.Vector2, thick: f32, color: rl.Color) void;
 pub extern "c" fn DrawCircle(centerX: c_int, centerY: c_int, radius: f32, color: rl.Color) void;
 pub extern "c" fn DrawCircleSector(center: rl.Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: c_int, color: rl.Color) void;
@@ -233,8 +233,8 @@ pub extern "c" fn DrawRectangleRounded(rec: rl.Rectangle, roundness: f32, segmen
 pub extern "c" fn DrawRectangleRoundedLines(rec: rl.Rectangle, roundness: f32, segments: c_int, lineThick: f32, color: rl.Color) void;
 pub extern "c" fn DrawTriangle(v1: rl.Vector2, v2: rl.Vector2, v3: rl.Vector2, color: rl.Color) void;
 pub extern "c" fn DrawTriangleLines(v1: rl.Vector2, v2: rl.Vector2, v3: rl.Vector2, color: rl.Color) void;
-pub extern "c" fn DrawTriangleFan(points: [*c]const rl.Vector2, pointCount: c_int, color: rl.Color) void;
-pub extern "c" fn DrawTriangleStrip(points: [*c]const rl.Vector2, pointCount: c_int, color: rl.Color) void;
+pub extern "c" fn DrawTriangleFan(points: [*c]rl.Vector2, pointCount: c_int, color: rl.Color) void;
+pub extern "c" fn DrawTriangleStrip(points: [*c]rl.Vector2, pointCount: c_int, color: rl.Color) void;
 pub extern "c" fn DrawPoly(center: rl.Vector2, sides: c_int, radius: f32, rotation: f32, color: rl.Color) void;
 pub extern "c" fn DrawPolyLines(center: rl.Vector2, sides: c_int, radius: f32, rotation: f32, color: rl.Color) void;
 pub extern "c" fn DrawPolyLinesEx(center: rl.Vector2, sides: c_int, radius: f32, rotation: f32, lineThick: f32, color: rl.Color) void;
@@ -259,7 +259,7 @@ pub extern "c" fn CheckCollisionCircleRec(center: rl.Vector2, radius: f32, rec: 
 pub extern "c" fn CheckCollisionPointRec(point: rl.Vector2, rec: rl.Rectangle) bool;
 pub extern "c" fn CheckCollisionPointCircle(point: rl.Vector2, center: rl.Vector2, radius: f32) bool;
 pub extern "c" fn CheckCollisionPointTriangle(point: rl.Vector2, p1: rl.Vector2, p2: rl.Vector2, p3: rl.Vector2) bool;
-pub extern "c" fn CheckCollisionPointPoly(point: rl.Vector2, points: [*c]const rl.Vector2, pointCount: c_int) bool;
+pub extern "c" fn CheckCollisionPointPoly(point: rl.Vector2, points: [*c]rl.Vector2, pointCount: c_int) bool;
 pub extern "c" fn CheckCollisionLines(startPos1: rl.Vector2, endPos1: rl.Vector2, startPos2: rl.Vector2, endPos2: rl.Vector2, collisionPoint: [*c]rl.Vector2) bool;
 pub extern "c" fn CheckCollisionPointLine(point: rl.Vector2, p1: rl.Vector2, p2: rl.Vector2, threshold: c_int) bool;
 pub extern "c" fn GetCollisionRec(rec1: rl.Rectangle, rec2: rl.Rectangle) rl.Rectangle;

--- a/lib/raylib-zig-ext.zig
+++ b/lib/raylib-zig-ext.zig
@@ -207,7 +207,7 @@ pub extern "c" fn DrawPixelV(position: rl.Vector2, color: rl.Color) void;
 pub extern "c" fn DrawLine(startPosX: c_int, startPosY: c_int, endPosX: c_int, endPosY: c_int, color: rl.Color) void;
 pub extern "c" fn DrawLineV(startPos: rl.Vector2, endPos: rl.Vector2, color: rl.Color) void;
 pub extern "c" fn DrawLineEx(startPos: rl.Vector2, endPos: rl.Vector2, thick: f32, color: rl.Color) void;
-pub extern "c" fn DrawLineStrip(points: [*c]rl.Vector2, pointCount: c_int, color: rl.Color) void;
+pub extern "c" fn DrawLineStrip(points: [*c]const rl.Vector2, pointCount: c_int, color: rl.Color) void;
 pub extern "c" fn DrawLineBezier(startPos: rl.Vector2, endPos: rl.Vector2, thick: f32, color: rl.Color) void;
 pub extern "c" fn DrawCircle(centerX: c_int, centerY: c_int, radius: f32, color: rl.Color) void;
 pub extern "c" fn DrawCircleSector(center: rl.Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: c_int, color: rl.Color) void;
@@ -233,8 +233,8 @@ pub extern "c" fn DrawRectangleRounded(rec: rl.Rectangle, roundness: f32, segmen
 pub extern "c" fn DrawRectangleRoundedLines(rec: rl.Rectangle, roundness: f32, segments: c_int, lineThick: f32, color: rl.Color) void;
 pub extern "c" fn DrawTriangle(v1: rl.Vector2, v2: rl.Vector2, v3: rl.Vector2, color: rl.Color) void;
 pub extern "c" fn DrawTriangleLines(v1: rl.Vector2, v2: rl.Vector2, v3: rl.Vector2, color: rl.Color) void;
-pub extern "c" fn DrawTriangleFan(points: [*c]rl.Vector2, pointCount: c_int, color: rl.Color) void;
-pub extern "c" fn DrawTriangleStrip(points: [*c]rl.Vector2, pointCount: c_int, color: rl.Color) void;
+pub extern "c" fn DrawTriangleFan(points: [*c]const rl.Vector2, pointCount: c_int, color: rl.Color) void;
+pub extern "c" fn DrawTriangleStrip(points: [*c]const rl.Vector2, pointCount: c_int, color: rl.Color) void;
 pub extern "c" fn DrawPoly(center: rl.Vector2, sides: c_int, radius: f32, rotation: f32, color: rl.Color) void;
 pub extern "c" fn DrawPolyLines(center: rl.Vector2, sides: c_int, radius: f32, rotation: f32, color: rl.Color) void;
 pub extern "c" fn DrawPolyLinesEx(center: rl.Vector2, sides: c_int, radius: f32, rotation: f32, lineThick: f32, color: rl.Color) void;
@@ -259,7 +259,7 @@ pub extern "c" fn CheckCollisionCircleRec(center: rl.Vector2, radius: f32, rec: 
 pub extern "c" fn CheckCollisionPointRec(point: rl.Vector2, rec: rl.Rectangle) bool;
 pub extern "c" fn CheckCollisionPointCircle(point: rl.Vector2, center: rl.Vector2, radius: f32) bool;
 pub extern "c" fn CheckCollisionPointTriangle(point: rl.Vector2, p1: rl.Vector2, p2: rl.Vector2, p3: rl.Vector2) bool;
-pub extern "c" fn CheckCollisionPointPoly(point: rl.Vector2, points: [*c]rl.Vector2, pointCount: c_int) bool;
+pub extern "c" fn CheckCollisionPointPoly(point: rl.Vector2, points: [*c]const rl.Vector2, pointCount: c_int) bool;
 pub extern "c" fn CheckCollisionLines(startPos1: rl.Vector2, endPos1: rl.Vector2, startPos2: rl.Vector2, endPos2: rl.Vector2, collisionPoint: [*c]rl.Vector2) bool;
 pub extern "c" fn CheckCollisionPointLine(point: rl.Vector2, p1: rl.Vector2, p2: rl.Vector2, threshold: c_int) bool;
 pub extern "c" fn GetCollisionRec(rec1: rl.Rectangle, rec2: rl.Rectangle) rl.Rectangle;

--- a/lib/raylib-zig.zig
+++ b/lib/raylib-zig.zig
@@ -1386,20 +1386,20 @@ pub fn loadMusicStreamFromMemory(fileType: [:0]const u8, data: []const u8) Music
     return cdef.LoadMusicStreamFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)));
 }
 
-pub fn drawLineStrip(points: []Vector2, color: Color) void {
-    cdef.DrawLineStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
+pub fn drawLineStrip(points: []const Vector2, color: Color) void {
+    cdef.DrawLineStrip(@as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn drawTriangleFan(points: []Vector2, color: Color) void {
-    cdef.DrawTriangleFan(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
+pub fn drawTriangleFan(points: []const Vector2, color: Color) void {
+    cdef.DrawTriangleFan(@as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn drawTriangleStrip(points: []Vector2, color: Color) void {
-    cdef.DrawTriangleStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
+pub fn drawTriangleStrip(points: []const Vector2, color: Color) void {
+    cdef.DrawTriangleStrip(@as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn checkCollisionPointPoly(point: Vector2, points: []Vector2) bool {
-    return cdef.CheckCollisionPointPoly(point, @as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
+pub fn checkCollisionPointPoly(point: Vector2, points: []const Vector2) bool {
+    return cdef.CheckCollisionPointPoly(point, @as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
 }
 
 pub fn loadFontEx(fileName: [:0]const u8, fontSize: i32, fontChars: []i32) Font {

--- a/lib/raylib-zig.zig
+++ b/lib/raylib-zig.zig
@@ -1386,20 +1386,20 @@ pub fn loadMusicStreamFromMemory(fileType: [:0]const u8, data: []const u8) Music
     return cdef.LoadMusicStreamFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)));
 }
 
-pub fn drawLineStrip(points: []const Vector2, color: Color) void {
-    cdef.DrawLineStrip(@as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
+pub fn drawLineStrip(points: []Vector2, color: Color) void {
+    cdef.DrawLineStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn drawTriangleFan(points: []const Vector2, color: Color) void {
-    cdef.DrawTriangleFan(@as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
+pub fn drawTriangleFan(points: []Vector2, color: Color) void {
+    cdef.DrawTriangleFan(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn drawTriangleStrip(points: []const Vector2, color: Color) void {
-    cdef.DrawTriangleStrip(@as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
+pub fn drawTriangleStrip(points: []Vector2, color: Color) void {
+    cdef.DrawTriangleStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn checkCollisionPointPoly(point: Vector2, points: []const Vector2) bool {
-    return cdef.CheckCollisionPointPoly(point, @as([*c]const Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
+pub fn checkCollisionPointPoly(point: Vector2, points: []Vector2) bool {
+    return cdef.CheckCollisionPointPoly(point, @as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
 }
 
 pub fn loadFontEx(fileName: [:0]const u8, fontSize: i32, fontChars: []i32) Font {

--- a/lib/raylib-zig.zig
+++ b/lib/raylib-zig.zig
@@ -1386,19 +1386,19 @@ pub fn loadMusicStreamFromMemory(fileType: [:0]const u8, data: []const u8) Music
     return cdef.LoadMusicStreamFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)));
 }
 
-pub fn drawLineStrip(points: []const Vector2, color: Color) void {
+pub fn drawLineStrip(points: []Vector2, color: Color) void {
     cdef.DrawLineStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn drawTriangleFan(points: []const Vector2, color: Color) void {
+pub fn drawTriangleFan(points: []Vector2, color: Color) void {
     cdef.DrawTriangleFan(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn drawTriangleStrip(points: []const Vector2, color: Color) void {
+pub fn drawTriangleStrip(points: []Vector2, color: Color) void {
     cdef.DrawTriangleStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
-pub fn checkCollisionPointPoly(point: Vector2, points: []const Vector2) bool {
+pub fn checkCollisionPointPoly(point: Vector2, points: []Vector2) bool {
     return cdef.CheckCollisionPointPoly(point, @as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
 }
 


### PR DESCRIPTION
`[]const Vector2` converted to `[*c]Vector2` which discards the const qualifier. Which throws an error.

I removed the const from `[]const Vector2` which fixed the issue. If you want to keep the `const` you can either use `@constCast`
or change `[*c]Vector2` to `[*c]const Vector2` and also change `cdef` counter part to also  `[*c]const Vector2` which may work. I haven't tested the last one.

There might be more functions also effected, but the ones I changed were the ones I located.

