### PR TITLE
Add build.* and emcc.zig to the zon paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,5 +8,5 @@
         },
     },
     .minimum_zig_version = "0.12.0",
-    .paths = .{ "lib/raylib.zig", "lib/raylib-ext.zig", "lib/raymath.zig", "lib/raymath-ext.zig", "lib/rlgl.zig", "lib/rlgl-ext.zig" },
+    .paths = .{ "build.zig", "build.zig.zon", "emcc.zig", "lib/raylib.zig", "lib/raylib-ext.zig", "lib/raymath.zig", "lib/raymath-ext.zig", "lib/rlgl.zig", "lib/rlgl-ext.zig" },
 }


### PR DESCRIPTION
As per some info found through https://github.com/ziglang/zig/issues/18282, this is apparently necessary to use this library as a dependency.