### PR TITLE
LazyPath.path deprecated in zig 0.12, removed in 0.13

### DIFF
--- a/emcc.zig
+++ b/emcc.zig
@@ -42,7 +42,7 @@ pub fn compileForEmscripten(
     // The project is built as a library and linked later.
     const exe_lib = b.addStaticLibrary(.{
         .name = name,
-        .root_source_file = .{ .path = root_source_file },
+        .root_source_file = b.path(root_source_file),
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
Zig changed a build thing, using b.path() instead

I checked that this works in 0.12