### PR TITLE
Modernize Installation Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Download and add raylib-zig as a dependency by running the following command in 
 zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz
 ```
 
-Then add raylib-zig as a dependency and import it's modules and artifact in your `build.zig`:
+Then add raylib-zig as a dependency and import its modules and artifact in your `build.zig`:
 
 ```zig
 const raylib_dep = b.dependency("raylib-zig", .{

--- a/README.md
+++ b/README.md
@@ -59,19 +59,10 @@ To build all available examples simply `zig build examples`. To list available e
 
 ### In an existing project (e.g. created with `zig init`)
 
-Create a `build.zig.zon` and add raylib-zig as a dependency like so:
+Download and add raylib-zig as a dependency by running the following command in your project root:
 
 ```
-.{
-    // ...
-    .dependencies = .{
-        .@"raylib-zig" = .{
-            .url = "https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz",
-            .hash = "12000000000000000000000000000000000000000000000000000000000000000000", // put the actual hash here
-        },
-    },
-    // ...
-}
+zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz
 ```
 
 Then add raylib-zig as a dependency and import it's modules and artifact in your `build.zig`:


### PR DESCRIPTION
`zig fetch` supported both in latest stable (0.13.0) and master (0.14.0-dev.130) as of writing