### PR TITLE
Make use of Zigs doc comments

### DIFF
--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -226,13 +226,13 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
             continue
 
         split_line = line.split(";", 1)
-        if len(split_line) == 1:
-            split_line.append("")
 
         line = split_line[0]
-        inline_comment = ""
-        if split_line[1].startswith("//"):
-            inline_comment = '/' + split_line[1]
+        if len(split_line) > 1:
+            desc = split_line[1].lstrip()
+            inline_comment = ("/" + desc) if len(desc) > 0 else ""
+        else:
+            inline_comment = ""
 
 
         if leftover:

--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -310,7 +310,7 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
 
             zig_types.add(arg_type)
             zig_c_arguments.append(arg_name + ": " + add_namespace_to_type(arg_type))  # Put everything together.
-            zig_arguments.append(arg_name + ": " + zig_type,)
+            zig_arguments.append(arg_name + ": " + zig_type)
             if arg_type == zig_type:
                 zig_call_args.append(arg_name)
             else:

--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -226,14 +226,13 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
             continue
 
         split_line = line.split(";", 1)
+        if len(split_line) == 1:
+            split_line.append("")
 
         line = split_line[0]
         inline_comment = ""
-        if len(split_line) > 1:
-            inline_comment = '/' + split_line[1].lstrip()
-            # sanity check
-            if inline_comment == "/":
-                inline_comment = ""
+        if split_line[1].startswith("//"):
+            inline_comment = '/' + split_line[1]
 
 
         if leftover:
@@ -369,7 +368,7 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
 
         if return_cast:
             zig_funcs.append(
-                (inline_comment if inline_comment != "" else "") +
+                inline_comment +
                 f"pub fn {zig_name}({zig_arguments}) {zig_return}" +
                 " {\n    " +
                 ("return " if zig_return != "void" else "") +

--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -55,7 +55,7 @@ def ziggify_type(name: str, t: str, func_name) -> str:
         "position", "mesh", "materialCount", "material", "model", "animCount",
         "wave", "v1", "v2", "outAxis", "outAngle", "fileSize",
         "AutomationEventList", "list", "batch", "glInternalFormat", "glFormat",
-        "glType", "mipmaps", "active", "scroll", "view", "checked", "mouseCell", 
+        "glType", "mipmaps", "active", "scroll", "view", "checked", "mouseCell",
         "scrollIndex", "focus", "secretViewActive", "color", "alpha", "colorHsv"
     ]
     multi = [
@@ -225,7 +225,16 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
         if not line.startswith(prefix):
             continue
 
-        line = line.split(";", 1)[0]
+        split_line = line.split(";", 1)
+
+        line = split_line[0]
+        inline_comment = ""
+        if len(split_line) > 1:
+            inline_comment = '/' + split_line[1].lstrip()
+            # sanity check
+            if inline_comment == "/":
+                inline_comment = ""
+
 
         if leftover:
             line = leftover + line
@@ -267,7 +276,7 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
         zig_c_arguments = []
         zig_arguments = []
         zig_call_args = []
-        
+
         if not arguments:
             arguments = "void"
 
@@ -301,7 +310,7 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
 
             zig_types.add(arg_type)
             zig_c_arguments.append(arg_name + ": " + add_namespace_to_type(arg_type))  # Put everything together.
-            zig_arguments.append(arg_name + ": " + zig_type)
+            zig_arguments.append(arg_name + ": " + zig_type,)
             if arg_type == zig_type:
                 zig_call_args.append(arg_name)
             else:
@@ -360,6 +369,7 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
 
         if return_cast:
             zig_funcs.append(
+                (inline_comment if inline_comment != "" else "") +
                 f"pub fn {zig_name}({zig_arguments}) {zig_return}" +
                 " {\n    " +
                 ("return " if zig_return != "void" else "") +

--- a/lib/preludes/raygui-prelude.zig
+++ b/lib/preludes/raygui-prelude.zig
@@ -412,6 +412,7 @@ pub const GuiIconName = enum(c_int) {
     icon_255 = 255,
 };
 
+/// Get raygui icons data pointer
 pub fn guiGetIcons() rl.RaylibError![]u32 {
     var res: []u32 = undefined;
 
@@ -424,18 +425,22 @@ pub fn guiGetIcons() rl.RaylibError![]u32 {
 }
 
 // If you REALLY need the return value of the function, you'll know what to do with it and its size yourself
+/// Load raygui icons file (.rgi) into internal icons data
 pub fn guiLoadIcons(fileName: [*c]const u8, loadIconsName: bool) [*c][*c]u8 {
     return cdef.GuiLoadIcons(fileName, loadIconsName);
 }
 
+/// Tab Bar control, returns TAB to be closed or -1
 pub fn guiTabBar(bounds: Rectangle, text: [][:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiTabBar(bounds, @as([*c][*c]const u8, @ptrCast(text)), @as(c_int, @intCast(text.len)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// List View with extended parameters
 pub fn guiListViewEx(bounds: Rectangle, text: [][:0]const u8, scrollIndex: *i32, active: *i32, focus: *i32) i32 {
     return @as(i32, cdef.GuiListViewEx(bounds, @as([*c][*c]const u8, @ptrCast(text)), @as(c_int, @intCast(text.len)), @as([*c]c_int, @ptrCast(scrollIndex)), @as([*c]c_int, @ptrCast(active)), @as([*c]c_int, @ptrCast(focus))));
 }
 
+/// Panel control, useful to group controls
 pub fn guiPanel(bounds: Rectangle, text: ?[:0]const u8) i32 {
     var textFinal = @as([*c]const u8, 0);
     if (text) |textSure| {
@@ -444,6 +449,7 @@ pub fn guiPanel(bounds: Rectangle, text: ?[:0]const u8) i32 {
     return @as(i32, cdef.GuiPanel(bounds, textFinal));
 }
 
+/// Scroll Panel control
 pub fn guiScrollPanel(bounds: Rectangle, text: ?[:0]const u8, content: Rectangle, scroll: *Vector2, view: *Rectangle) i32 {
     var textFinal = @as([*c]const u8, 0);
     if (text) |textSure| {

--- a/lib/preludes/raylib-prelude.zig
+++ b/lib/preludes/raylib-prelude.zig
@@ -20,122 +20,156 @@ pub const Vector2 = extern struct {
         return Vector2{ .x = x, .y = y };
     }
 
+    /// Vector with components value 0.0
     pub fn zero() Vector2 {
         return math.vector2Zero();
     }
 
+    /// Vector with components value 1.0
     pub fn one() Vector2 {
         return math.vector2One();
     }
 
+    /// Add two vectors (v1 + v2)
     pub fn add(self: Vector2, v: Vector2) Vector2 {
         return math.vector2Add(self, v);
     }
 
+    /// Add vector and float value
     pub fn addValue(self: Vector2, v: f32) Vector2 {
         return math.vector2AddValue(self, v);
     }
 
+    /// Subtract two vectors (v1 - v2)
     pub fn subtract(self: Vector2, v: Vector2) Vector2 {
         return math.vector2Subtract(self, v);
     }
 
+    /// Subtract vector by float value
     pub fn subtractValue(self: Vector2, v: f32) Vector2 {
         return math.vector2SubtractValue(self, v);
     }
 
+    /// Calculate vector length
     pub fn length(self: Vector2) f32 {
         return math.vector2Length(self);
     }
 
+    /// Calculate vector square length
     pub fn lengthSqr(self: Vector2) f32 {
         return math.vector2LengthSqr(self);
     }
 
+    /// Calculate two vectors dot product
     pub fn dotProduct(self: Vector2, v: Vector2) f32 {
         return math.vector2DotProduct(self, v);
     }
 
+    /// Calculate distance between two vectors
     pub fn distance(self: Vector2, v: Vector2) f32 {
         return math.vector2Distance(self, v);
     }
 
+    /// Calculate square distance between two vectors
     pub fn distanceSqr(self: Vector2, v: Vector2) f32 {
         return math.vector2DistanceSqr(self, v);
     }
 
+    /// Calculate angle from two vectors
     pub fn angle(self: Vector2, v: Vector2) f32 {
         return math.vector2Angle(self, v);
     }
 
+    /// Calculate angle defined by a two vectors line
     pub fn lineAngle(self: Vector2, end: Vector2) f32 {
         return math.vector2LineAngle(self, end);
     }
 
+    /// Scale vector (multiply by value)
     pub fn scale(self: Vector2, scale_: f32) Vector2 {
         return math.vector2Scale(self, scale_);
     }
 
+    /// Multiply vector by vector
     pub fn multiply(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Multiply(self, v2);
     }
 
+    /// Negate vector
     pub fn negate(self: Vector2) Vector2 {
         return math.vector2Negate(self);
     }
 
+    /// Divide vector by vector
     pub fn divide(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Divide(self, v2);
     }
 
+    /// Normalize provided vector
     pub fn normalize(self: Vector2) Vector2 {
         return math.vector2Normalize(self);
     }
 
+    /// Transforms a Vector2 by a given Matrix
     pub fn transform(self: Vector2, mat: Matrix) Vector2 {
         return math.vector2Transform(self, mat);
     }
 
+    /// Calculate linear interpolation between two vectors
     pub fn lerp(self: Vector2, v2: Vector2, amount: f32) Vector2 {
         return math.vector2Lerp(self, v2, amount);
     }
 
+    /// Calculate reflected vector to normal
     pub fn reflect(self: Vector2, normal: Vector2) Vector2 {
         return math.vector2Reflect(self, normal);
     }
 
+    /// Get min value for each pair of components
     pub fn min(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Min(self, v2);
     }
 
+    /// Get max value for each pair of components
     pub fn max(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Max(self, v2);
     }
 
+    /// Rotate vector by angle
     pub fn rotate(self: Vector2, angle_: f32) Vector2 {
         return math.vector2Rotate(self, angle_);
     }
 
+    /// Move Vector towards target
     pub fn moveTowards(self: Vector2, target: Vector2, maxDistance: f32) Vector2 {
         return math.vector2MoveTowards(self, target, maxDistance);
     }
 
+    /// Invert the given vector
     pub fn invert(self: Vector2) Vector2 {
         return math.vector2Invert(self);
     }
 
+    /// Clamp the components of the vector between min and max values specified by the given vectors
     pub fn clamp(self: Vector2, min_: Vector2, max_: Vector2) Vector2 {
         return math.vector2Clamp(self, min_, max_);
     }
 
+    /// Clamp the magnitude of the vector between two min and max values
     pub fn clampValue(self: Vector2, min_: f32, max_: f32) Vector2 {
         return math.vector2ClampValue(self, min_, max_);
     }
 
+    /// Check whether two given vectors are almost equal
     pub fn equals(self: Vector2, q: Vector2) i32 {
         return math.vector2Equals(self, q);
     }
 
+    /// Compute the direction of a refracted ray
+    /// v: normalized direction of the incoming ray
+    /// n: normalized normal vector of the interface of two optical media
+    /// r: ratio of the refractive index of the medium from where the ray comes
+    ///    to the refractive index of the medium on the other side of the surface
     pub fn refract(self: Vector2, n: Vector2, r: f32) Vector2 {
         return math.vector2Refract(self, n, r);
     }
@@ -150,158 +184,205 @@ pub const Vector3 = extern struct {
         return Vector3{ .x = x, .y = y, .z = z };
     }
 
+    // Vector with components value 0.0
     pub fn zero() Vector3 {
         return math.vector3Zero();
     }
 
+    /// Vector with components value 1.0
     pub fn one() Vector3 {
         return math.vector3One();
     }
 
+    /// Add two vectors
     pub fn add(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Add(self, v);
     }
 
+    /// Add vector and float value
     pub fn addValue(self: Vector3, add_: f32) Vector3 {
         return math.vector3AddValue(self, add_);
     }
 
+    /// Subtract two vectors
     pub fn subtract(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Subtract(self, v);
     }
 
+    /// Subtract vector by float value
     pub fn subtractValue(self: Vector3, sub: f32) Vector3 {
         return math.vector3SubtractValue(self, sub);
     }
 
+    /// Multiply vector by scalar
     pub fn scale(self: Vector3, scalar: f32) Vector3 {
         return math.vector3Scale(self, scalar);
     }
 
+    /// Multiply vector by vector
     pub fn multiply(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Multiply(self, v);
     }
 
+    /// Calculate two vectors cross product
     pub fn crossProduct(self: Vector3, v: Vector3) Vector3 {
         return math.vector3CrossProduct(self, v);
     }
 
+    /// Calculate one vector perpendicular vector
     pub fn perpendicular(self: Vector3) Vector3 {
         return math.vector3Perpendicular(self);
     }
 
+    /// Calculate vector length
     pub fn length(self: Vector3) f32 {
         return math.vector3Length(self);
     }
 
+    /// Calculate vector square length
     pub fn lengthSqr(self: Vector3) f32 {
         return math.vector3LengthSqr(self);
     }
 
+    /// Calculate two vectors dot product
     pub fn dotProduct(self: Vector3, v: Vector3) f32 {
         return math.vector3DotProduct(self, v);
     }
 
+    /// Calculate distance between two vectors
     pub fn distance(self: Vector3, v: Vector3) f32 {
         return math.vector3Distance(self, v);
     }
 
+    /// Calculate square distance between two vectors
     pub fn distanceSqr(self: Vector3, v: Vector3) f32 {
         return math.vector3DistanceSqr(self, v);
     }
 
+    /// Calculate angle between two vectors
     pub fn angle(self: Vector3, v: Vector3) f32 {
         return math.vector3Angle(self, v);
     }
 
+    /// Negate vector (invert direction)
     pub fn negate(self: Vector3) Vector3 {
         return math.vector3Negate(self);
     }
 
+    /// Divide vector by vector
     pub fn divide(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Divide(self, v);
     }
 
+    /// Normalize provided vector
     pub fn normalize(self: Vector3) Vector3 {
         return math.vector3Normalize(self);
     }
 
+    /// Calculate the projection of the vector v1 on to v2
     pub fn project(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Project(self, v);
     }
 
+    /// Calculate the rejection of the vector v1 on to v2
     pub fn reject(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Reject(self, v);
     }
 
+    /// Orthonormalize provided vectors Makes vectors normalized and orthogonal
+    /// to each other Gram-Schmidt function implementation
     pub fn orthoNormalize(self: *Vector3, v: *Vector3) void {
         math.vector3OrthoNormalize(self, v);
     }
 
+    /// Transforms a Vector3 by a given Matrix
     pub fn transform(self: Vector3, mat: Matrix) Vector3 {
         return math.vector3Transform(self, mat);
     }
 
+    /// Transform a vector by quaternion rotation
     pub fn rotateByQuaternion(self: Vector3, q: Quaternion) Vector3 {
         return math.vector3RotateByQuaternion(self, q);
     }
 
+    /// Rotates a vector around an axis
     pub fn rotateByAxisAngle(self: Vector3, axis: Vector3, angle_: f32) Vector3 {
         return math.vector3RotateByAxisAngle(self, axis, angle_);
     }
 
+    /// Move Vector towards target
     pub fn moveTowards(self: Vector3, target: Vector3, maxDistance: f32) Vector3 {
         return math.vector3MoveTowards(self, target, maxDistance);
     }
 
+    /// Calculate linear interpolation between two vectors
     pub fn lerp(self: Vector3, v2: Vector3, amount: f32) Vector3 {
         return math.vector3Lerp(self, v2, amount);
     }
 
+    /// Calculate cubic hermite interpolation between two vectors and their tangents
+    /// as described in the GLTF 2.0 specification
     pub fn cubicHermite(self: Vector3, tangent1: Vector3, v: Vector3, tangent2: Vector3, amount: f32) Vector3 {
         return math.vector3CubicHermite(self, tangent1, v, tangent2, amount);
     }
 
+    /// Calculate reflected vector to normal
     pub fn reflect(self: Vector3, normal: Vector3) Vector3 {
         return math.vector3Reflect(self, normal);
     }
 
+    /// Get min value for each pair of components
     pub fn min(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Min(self, v);
     }
 
+    /// Get max value for each pair of components
     pub fn max(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Max(self, v);
     }
 
+    /// Compute barycenter coordinates (u, v, w) for point p with respect to triangle
+    /// (a, b, c) NOTE: Assumes P is on the plane of the triangle
     pub fn barycenter(p: Vector3, a: Vector3, b: Vector3, c: Vector3) Vector3 {
         return math.vector3Barycenter(p, a, b, c);
     }
 
+    /// Projects a Vector3 from screen space into object space
+    /// NOTE: We are avoiding calling other raymath functions despite available
     pub fn unproject(source: Vector3, projection: Matrix, view: Matrix) Vector3 {
         return math.vector3Unproject(source, projection, view);
     }
 
+    /// Get Vector3 as float array
     pub fn toFloatV(self: Vector3) math.float3 {
         return math.vector3ToFloatV(self);
     }
 
+    /// Invert the given vector
     pub fn invert(self: Vector3) Vector3 {
         return math.vector3Invert(self);
     }
 
+    /// Clamp the components of the vector between min and max values specified by the given vectors
     pub fn clamp(self: Vector3, min_: Vector3, max_: Vector3) Vector3 {
         return math.vector3Clamp(self, min_, max_);
     }
 
+    /// Clamp the magnitude of the vector between two values
     pub fn clampValue(self: Vector3, min_: f32, max_: f32) Vector3 {
         return math.vector3ClampValue(self, min_, max_);
     }
 
+    /// Check whether two given vectors are almost equal
     pub fn equals(p: Vector3, q: Vector3) i32 {
         return math.vector3Equals(p, q);
     }
 
+    /// Compute the direction of a refracted ray
+    /// v: normalized direction of the incoming ray
+    /// n: normalized normal vector of the interface of two optical media
+    /// r: ratio of the refractive index of the medium from where the ray comes
+    ///    to the refractive index of the medium on the other side of the surface
     pub fn refract(self: Vector3, n: Vector3, r: f32) Vector3 {
         return math.vector3Refract(self, n, r);
     }
@@ -317,138 +398,176 @@ pub const Vector4 = extern struct {
         return Vector4{ .x = x, .y = y, .z = z, .w = w };
     }
 
+    /// Vector with components value 0.0
     pub fn zero() Vector4 {
         return math.vector4Zero();
     }
 
+    /// Vector with components value 1.0
     pub fn one() Vector4 {
         return math.vector4One();
     }
 
+    /// Add two vectors
     pub fn add(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Add(self, v);
     }
 
+    /// Add vector and float value
     pub fn addValue(self: Vector4, add_: f32) Vector4 {
         return math.vector4AddValue(self, add_);
     }
 
+    /// Subtract two vectors
     pub fn subtract(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Subtract(self, v);
     }
 
+    /// Subtract vector and float value
     pub fn subtractValue(self: Vector4, add_: f32) Vector4 {
         return math.vector4SubtractValue(self, add_);
     }
 
+    /// Computes the length of a vector
     pub fn length(self: Vector4) f32 {
         return math.vector4Length(self);
     }
 
+    /// Calculate vector square length
     pub fn lengthSqr(self: Vector4) f32 {
         return math.vector4LengthSqr(self);
     }
 
+    /// Calculate two vectors dot product
     pub fn dotProduct(self: Vector4, v: Vector4) f32 {
         return math.vector4DotProduct(self, v);
     }
 
+    /// Calculate distance between two vectors
     pub fn distance(self: Vector4, v: Vector4) f32 {
         return math.vector4Distance(self, v);
     }
 
+    /// Calculate square distance between two vectors
     pub fn distanceSqr(self: Vector4, v: Vector4) f32 {
         return math.vector4DistanceSqr(self, v);
     }
 
+    /// Scale vector by float value
     pub fn scale(self: Vector4, scale_: f32) Vector4 {
         return math.vector4Scale(self, scale_);
     }
 
+    /// Multiply vector by vector
     pub fn multiply(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Multiply(self, v);
     }
 
+    /// Negate vector
     pub fn negate(self: Vector4) Vector4 {
         return math.vector4Negate(self);
     }
 
+    /// Divide two vectors
     pub fn divide(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Divide(self, v);
     }
 
+    /// Normalize vector
     pub fn normalize(self: Vector4) Vector4 {
         return math.vector4Normalize(self);
     }
 
+    /// Get min value for each pair of components
     pub fn min(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Min(self, v);
     }
 
+    /// Get max value for each pair of components
     pub fn max(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Max(self, v);
     }
 
+    /// Calculate linear interpolation between two vectors
     pub fn lerp(self: Vector4, v: Vector4, amount: f32) Vector4 {
         return math.vector4Lerp(self, v, amount);
     }
 
+    /// Move Vector towards target
     pub fn moveTowards(self: Vector4, target: Vector4, maxDistance: f32) Vector4 {
         return math.vector4MoveTowards(self, target, maxDistance);
     }
 
+    /// Invert provided quaternion
     pub fn invert(self: Vector4) Vector4 {
         return math.vector4Invert(self);
     }
 
+    /// Check whether two given quaternions are almost equal
     pub fn equals(p: Vector4, q: Vector4) i32 {
         return math.vector4Equals(p, q);
     }
 
+    /// Get identity quaternion
     pub fn identity() Quaternion {
         return math.quaternionIdentity();
     }
 
+    /// Calculate slerp-optimized interpolation between two quaternions
     pub fn nlerp(self: Quaternion, q: Quaternion, amount: f32) Quaternion {
         return math.quaternionNlerp(self, q, amount);
     }
 
+    /// Calculates spherical linear interpolation between two quaternions
     pub fn slerp(self: Quaternion, q: Quaternion, amount: f32) Quaternion {
         return math.quaternionSlerp(self, q, amount);
     }
 
+    /// Calculate quaternion cubic spline interpolation using Cubic Hermite Spline
+    /// algorithm as described in the GLTF 2.0 specification
     pub fn cubicHermiteSpline(self: Quaternion, outTangent1: Quaternion, q: Quaternion, inTangent2: Quaternion, t: f32) Quaternion {
         return math.quaternionCubicHermiteSpline(self, outTangent1, q, inTangent2, t);
     }
 
+    // Calculate quaternion based on the rotation from one vector to another
     pub fn fromVector3ToVector3(from: Vector3, to: Vector3) Quaternion {
         return math.quaternionFromVector3ToVector3(from, to);
     }
 
+    /// Get a quaternion for a given rotation matrix
     pub fn fromMatrix(mat: Matrix) Quaternion {
         return math.quaternionFromMatrix(mat);
     }
 
+    /// Get a matrix for a given quaternion
     pub fn toMatrix(self: Quaternion) Matrix {
         return math.quaternionToMatrix(self);
     }
 
+    /// Get rotation quaternion for an angle and axis
+    /// NOTE: Angle must be provided in radians
     pub fn fromAxisAngle(axis: Vector3, angle: f32) Quaternion {
         return math.quaternionFromAxisAngle(axis, angle);
     }
 
+    /// Get the rotation angle and axis for a given quaternion
     pub fn toAxisAngle(self: Quaternion, outAxis: *Vector3, outAngle: *f32) void {
         math.quaternionToAxisAngle(self, outAxis, outAngle);
     }
 
+    /// Get the quaternion equivalent to Euler angles
+    /// NOTE: Rotation order is ZYX
     pub fn fromEuler(pitch: f32, yaw: f32, roll: f32) Quaternion {
         return math.quaternionFromEuler(pitch, yaw, roll);
     }
 
+    /// Get the Euler angles equivalent to quaternion (roll, pitch, yaw)
+    /// NOTE: Angles are returned in a Vector3 struct in radians
     pub fn toEuler(self: Quaternion) Vector3 {
         return math.quaternionToEuler(self);
     }
 
+    /// Transform a quaternion given a transformation matrix
     pub fn transform(self: Quaternion, mat: Matrix) Quaternion {
         return math.quaternionTransform(self, mat);
     }
@@ -473,86 +592,115 @@ pub const Matrix = extern struct {
     m11: f32,
     m15: f32,
 
+    /// Compute matrix determinant
     pub fn determinant(self: Matrix) f32 {
         return math.matrixDeterminant(self);
     }
 
+    /// Get the trace of the matrix (sum of the values along the diagonal)
     pub fn trace(self: Matrix) f32 {
         return math.matrixTrace(self);
     }
 
+    /// Transposes provided matrix
     pub fn transpose(self: Matrix) Matrix {
         return math.matrixTranspose(self);
     }
 
+    /// Invert provided matrix
     pub fn invert(self: Matrix) Matrix {
         return math.matrixInvert(self);
     }
 
+    /// Get identity matrix
     pub fn identity() Matrix {
         return math.matrixIdentity();
     }
 
+    /// Add two matrices
     pub fn add(self: Matrix, right: Matrix) Matrix {
         return math.matrixAdd(self, right);
     }
 
+    /// Subtract two matrices (left - right)
     pub fn subtract(self: Matrix, right: Matrix) Matrix {
         return math.matrixSubtract(self, right);
     }
 
+    /// Get two matrix multiplication
+    /// NOTE: When multiplying matrices... the order matters!
     pub fn multiply(self: Matrix, right: Matrix) Matrix {
         return math.matrixMultiply(self, right);
     }
 
+    /// Get translation matrix
     pub fn translate(x: f32, y: f32, z: f32) Matrix {
         return math.matrixTranslate(x, y, z);
     }
 
+    /// Create rotation matrix from axis and angle
+    /// NOTE: Angle should be provided in radians
     pub fn rotate(axis: Vector3, angle: f32) Matrix {
         return math.matrixRotate(axis, angle);
     }
 
+    /// Get x-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateX(angle: f32) Matrix {
         return math.matrixRotateX(angle);
     }
 
+    /// Get y-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateY(angle: f32) Matrix {
         return math.matrixRotateY(angle);
     }
 
+    /// Get z-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateZ(angle: f32) Matrix {
         return math.matrixRotateZ(angle);
     }
 
+    /// Get xyz-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateXYZ(angle: Vector3) Matrix {
         return math.matrixRotateXYZ(angle);
     }
 
+    /// Get zyx-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateZYX(angle: Vector3) Matrix {
         return math.matrixRotateZYX(angle);
     }
 
+    /// Get scaling matrix
     pub fn scale(x: f32, y: f32, z: f32) Matrix {
         return math.matrixScale(x, y, z);
     }
 
+    /// Get perspective projection matrix
     pub fn frustum(left: f64, right: f64, bottom: f64, top: f64, near: f64, far: f64) Matrix {
         return math.matrixFrustum(left, right, bottom, top, near, far);
     }
 
+    /// Get perspective projection matrix
+    /// NOTE: Fovy angle must be provided in radians
     pub fn perspective(fovY: f64, aspect: f64, nearPlane: f64, farPlane: f64) Matrix {
         return math.matrixPerspective(fovY, aspect, nearPlane, farPlane);
     }
 
+    /// Get orthographic projection matrix
     pub fn ortho(left: f64, right: f64, bottom: f64, top: f64, nearPlane: f64, farPlane: f64) Matrix {
         return math.matrixOrtho(left, right, bottom, top, nearPlane, farPlane);
     }
 
+    /// Get camera look-at matrix (view matrix)
     pub fn lookAt(eye: Vector3, target: Vector3, up: Vector3) Matrix {
         return math.matrixLookAt(eye, target, up);
     }
 
+    /// Get float array of matrix data
     pub fn toFloatV(self: Matrix) math.float16 {
         return math.matrixToFloatV(self);
     }
@@ -596,46 +744,57 @@ pub const Color = extern struct {
         return Color{ .r = r, .g = g, .b = b, .a = a };
     }
 
+    /// Get Color from normalized values [0..1]
     pub fn fromNormalized(normalized: Vector4) Color {
         return rl.colorFromNormalized(normalized);
     }
 
+    /// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
     pub fn fromHSV(hue: f32, saturation: f32, value: f32) Color {
         return rl.colorFromHSV(hue, saturation, value);
     }
 
+    /// Get a Color from hexadecimal value
     pub fn fromInt(hexValue: u32) Color {
         return rl.getColor(hexValue);
     }
 
+    /// Get color with alpha applied, alpha goes from 0.0 to 1.0
     pub fn fade(self: Color, a: f32) Color {
         return rl.fade(self, a);
     }
 
+    /// Get color multiplied with another color
     pub fn tint(self: Color, t: Color) Color {
         return rl.colorTint(self, t);
     }
 
+    /// Get Color normalized as float [0..1]
     pub fn normalize(self: Color) Vector4 {
         return rl.colorNormalize(self);
     }
 
+    /// Get color with brightness correction, brightness factor goes from -1.0 to 1.0
     pub fn brightness(self: Color, factor: f32) Color {
         return rl.colorBrightness(self, factor);
     }
 
+    /// Get color with contrast correction, contrast values between -1.0 and 1.0
     pub fn contrast(self: Color, c: f32) Color {
         return rl.colorContrast(self, c);
     }
 
+    /// Get color with alpha applied, alpha goes from 0.0 to 1.0
     pub fn alpha(self: Color, a: f32) Color {
         return rl.colorAlpha(self, a);
     }
 
+    /// Get hexadecimal value for a Color
     pub fn toInt(self: Color) i32 {
         return rl.colorToInt(self);
     }
 
+    /// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
     pub fn toHSV(self: Color) Vector3 {
         return rl.colorToHSV(self);
     }
@@ -651,10 +810,12 @@ pub const Rectangle = extern struct {
         return Rectangle{ .x = x, .y = y, .width = width, .height = height };
     }
 
+    /// Check collision between two rectangles
     pub fn checkCollision(self: Rectangle, rec2: Rectangle) bool {
         return rl.checkCollisionRecs(self, rec2);
     }
 
+    /// Get collision rectangle for two rectangles collision
     pub fn getCollision(self: Rectangle, rec2: Rectangle) Rectangle {
         return rl.getCollisionRec(self, rec2);
     }
@@ -667,262 +828,327 @@ pub const Image = extern struct {
     mipmaps: c_int,
     format: PixelFormat,
 
+    /// Load image from file into CPU memory (RAM)
     pub fn init(fileName: [:0]const u8) Image {
         return rl.loadImage(fileName);
     }
 
+    /// Load image from RAW file data
     pub fn initRaw(fileName: [:0]const u8, width: i32, height: i32, format: PixelFormat, headerSize: i32) Image {
         return rl.loadImageRaw(fileName, width, height, format, headerSize);
     }
 
+    /// Load image sequence from file (frames appended to image.data)
     pub fn initAnim(fileName: [:0]const u8, frames: *i32) Image {
         return rl.loadImageAnim(fileName, frames);
     }
 
+    /// Load image from GPU texture data
     pub fn fromTexture(texture: Texture) Image {
         return rl.loadImageFromTexture(texture);
     }
 
+    /// Load image from screen buffer and (screenshot)
     pub fn fromScreen() Image {
         return rl.loadImageFromScreen();
     }
 
+    /// Unload image from CPU memory (RAM)
     pub fn unload(self: Image) void {
         rl.unloadImage(self);
     }
 
+    /// Create an image from text (default font)
     pub fn initText(text: [:0]const u8, fontSize: i32, color: Color) Image {
         return rl.imageText(text, fontSize, color);
     }
 
+    /// Create an image from text (custom sprite font)
     pub fn initTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32, t: Color) Image {
         return rl.imageTextEx(font, text, fontSize, spacing, t);
     }
 
+    /// Generate image: plain color
     pub fn genColor(width: i32, height: i32, color: Color) Image {
         return rl.genImageColor(width, height, color);
     }
 
+    /// Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
     pub fn genGradientLinear(width: i32, height: i32, direction: i32, start: Color, end: Color) Image {
         return rl.genImageGradientLinear(width, height, direction, start, end);
     }
 
+    /// Generate image: radial gradient
     pub fn genGradientRadial(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
         return rl.genImageGradientRadial(width, height, density, inner, outer);
     }
 
+    /// Generate image: square gradient
     pub fn genGradientSquare(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
         return rl.genImageGradientSquare(width, height, density, inner, outer);
     }
 
+    /// Generate image: checked
     pub fn genChecked(width: i32, height: i32, checksX: i32, checksY: i32, col1: Color, col2: Color) Image {
         return rl.genImageChecked(width, height, checksX, checksY, col1, col2);
     }
 
+    /// Generate image: white noise
     pub fn genWhiteNoise(width: i32, height: i32, factor: f32) Image {
         return rl.genImageWhiteNoise(width, height, factor);
     }
 
+    /// Generate image: perlin noise
     pub fn genPerlinNoise(width: i32, height: i32, offsetX: i32, offsetY: i32, scale: f32) Image {
         return rl.genImagePerlinNoise(width, height, offsetX, offsetY, scale);
     }
 
+    /// Generate image: cellular algorithm, bigger tileSize means bigger cells
     pub fn genCellular(width: i32, height: i32, tileSize: i32) Image {
         return rl.genImageCellular(width, height, tileSize);
     }
 
+    /// Generate image: grayscale image from text data
     pub fn genText(width: i32, height: i32, text: [:0]const u8) Image {
         return rl.genImageText(width, height, text);
     }
 
+    /// Create an image duplicate (useful for transformations)
     pub fn copy(self: Image) Image {
         return rl.imageCopy(self);
     }
 
+    /// Create an image from another image piece
     pub fn copyRec(self: Image, rec: Rectangle) Image {
         return rl.imageFromImage(self, rec);
     }
 
+    /// Convert image data to desired format
     pub fn setFormat(self: *Image, newFormat: PixelFormat) void {
         return rl.imageFormat(self, newFormat);
     }
 
+    /// Convert image to POT (power-of-two)
     pub fn toPOT(self: *Image, fill: Color) void {
         rl.imageToPOT(self, fill);
     }
 
+    /// Crop an image to a defined rectangle
     pub fn crop(self: *Image, c: Rectangle) void {
         rl.imageCrop(self, c);
     }
 
+    /// Crop image depending on alpha value
     pub fn alphaCrop(self: *Image, threshold: f32) void {
         rl.imageAlphaCrop(self, threshold);
     }
 
+    /// Clear alpha channel to desired color
     pub fn alphaClear(self: *Image, color: Color, threshold: f32) void {
         rl.imageAlphaClear(self, color, threshold);
     }
 
+    /// Apply alpha mask to image
     pub fn alphaMask(self: *Image, am: Image) void {
         rl.imageAlphaMask(self, am);
     }
 
+    /// Premultiply alpha channel
     pub fn alphaPremultiply(self: *Image) void {
         rl.imageAlphaPremultiply(self);
     }
 
+    /// Apply Gaussian blur using a box blur approximation
     pub fn blurGaussian(self: *Image, blurSize: i32) void {
         rl.imageBlurGaussian(self, blurSize);
     }
 
+    /// Resize image (Bicubic scaling algorithm)
     pub fn resize(self: *Image, newWidth: i32, newHeight: i32) void {
         rl.imageResize(self, newWidth, newHeight);
     }
 
+    /// Resize image (Nearest-Neighbor scaling algorithm)
     pub fn resizeNN(self: *Image, newWidth: i32, newHeight: i32) void {
         rl.imageResizeNN(self, newWidth, newHeight);
     }
 
+    /// Resize canvas and fill with color
     pub fn resizeCanvas(self: *Image, newWidth: i32, newHeight: i32, offsetX: i32, offsetY: i32, fill: Color) void {
         rl.imageResizeCanvas(self, newWidth, newHeight, offsetX, offsetY, fill);
     }
 
+    /// Compute all mipmap levels for a provided image
     pub fn mimaps(self: *Image) void {
         rl.imageMipmaps(self);
     }
 
+    /// Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
     pub fn dither(self: *Image, rBpp: i32, gBpp: i32, bBpp: i32, aBpp: i32) void {
         rl.imageDither(self, rBpp, gBpp, bBpp, aBpp);
     }
 
+    /// Flip image vertically
     pub fn flipVertical(self: *Image) void {
         rl.imageFlipVertical(self);
     }
 
+    /// Flip image horizontally
     pub fn flipHorizontal(self: *Image) void {
         rl.imageFlipHorizontal(self);
     }
 
+    /// Rotate image by input angle in degrees (-359 to 359)
     pub fn rotate(self: *Image, degrees: i32) void {
         rl.imageRotate(self, degrees);
     }
 
+    /// Rotate image clockwise 90deg
     pub fn rotateCW(self: *Image) void {
         rl.imageRotateCW(self);
     }
 
+    /// Rotate image counter-clockwise 90deg
     pub fn rotateCCW(self: *Image) void {
         rl.imageRotateCCW(self);
     }
 
+    /// Modify image color: tint
     pub fn tint(self: *Image, color: Color) void {
         rl.imageColorTint(self, color);
     }
 
+    /// Modify image color: invert
     pub fn invert(self: *Image) void {
         rl.imageColorInvert(self);
     }
 
+    /// Modify image color: grayscale
     pub fn grayscale(self: *Image) void {
         rl.imageColorGrayscale(self);
     }
 
+    /// Modify image color: contrast (-100 to 100)
     pub fn contrast(self: *Image, c: f32) void {
         rl.imageColorContrast(self, c);
     }
 
+    /// Modify image color: brightness (-255 to 255)
     pub fn brightness(self: *Image, b: i32) void {
         rl.imageColorBrightness(self, b);
     }
 
+    /// Modify image color: replace color
     pub fn replaceColor(self: *Image, color: Color, replace: Color) void {
         rl.imageColorReplace(self, color, replace);
     }
 
+    /// Get image alpha border rectangle
     pub fn getAlphaBorder(self: Image, threshold: f32) Rectangle {
         return rl.getImageAlphaBorder(self, threshold);
     }
 
+    /// Get image pixel color at (x, y) position
     pub fn getColor(self: Image, x: i32, y: i32) Color {
         return rl.getImageColor(self, x, y);
     }
 
+    /// Clear image background with given color
     pub fn clearBackground(self: *Image, color: Color) void {
         rl.imageClearBackground(self, color);
     }
 
+    /// Draw pixel within an image
     pub fn drawPixel(self: *Image, posX: i32, posY: i32, color: Color) void {
         rl.imageDrawPixel(self, posX, posY, color);
     }
 
+    /// Draw pixel within an image (Vector version)
     pub fn drawPixelV(self: *Image, position: Vector2, color: Color) void {
         rl.imageDrawPixelV(self, position, color);
     }
 
+    /// Draw line within an image
     pub fn drawLine(self: *Image, startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
         rl.imageDrawLine(self, startPosX, startPosY, endPosX, endPosY, color);
     }
 
+    /// Draw line within an image (Vector version)
     pub fn drawLineV(self: *Image, start: Vector2, end: Vector2, color: Color) void {
         rl.imageDrawLineV(self, start, end, color);
     }
 
+    /// Draw a filled circle within an image
     pub fn drawCircle(self: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
         rl.imageDrawCircle(self, centerX, centerY, radius, color);
     }
 
+    /// Draw a filled circle within an image (Vector version)
     pub fn drawCircleV(self: *Image, center: Vector2, radius: i32, color: Color) void {
         rl.imageDrawCircleV(self, center, radius, color);
     }
 
+    /// Draw circle outline within an image
     pub fn drawCircleLines(self: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
         rl.imageDrawCircleLines(self, centerX, centerY, radius, color);
     }
 
+    /// Draw circle outline within an image (Vector version)
     pub fn drawCircleLinesV(self: *Image, center: Vector2, radius: i32, color: Color) void {
         rl.imageDrawCircleLinesV(self, center, radius, color);
     }
 
+    /// Draw rectangle within an image
     pub fn drawRectangle(self: *Image, posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
         rl.imageDrawRectangle(self, posX, posY, width, height, color);
     }
 
+    /// Draw rectangle within an image (Vector version)
     pub fn drawRectangleV(self: *Image, position: Vector2, size: Vector2, color: Color) void {
         rl.imageDrawRectangleV(self, position, size, color);
     }
 
+    /// Draw rectangle within an image
     pub fn drawRectangleRec(self: *Image, rec: Rectangle, color: Color) void {
         rl.imageDrawRectangleRec(self, rec, color);
     }
 
+    /// Draw rectangle lines within an image
     pub fn drawRectangleLines(self: *Image, rec: Rectangle, thick: i32, color: Color) void {
         rl.imageDrawRectangleLines(self, rec, thick, color);
     }
 
+    /// Draw a source image within a destination image (tint applied to source)
     pub fn drawImage(self: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, t: Color) void {
         rl.imageDraw(self, src, srcRec, dstRec, t);
     }
 
+    /// Draw text (using default font) within an image (destination)
     pub fn drawText(self: *Image, text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
         rl.imageDrawText(self, text, posX, posY, fontSize, color);
     }
 
+    /// Draw text (custom sprite font) within an image (destination)
     pub fn drawTextEx(self: *Image, font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, t: Color) void {
         rl.imageDrawTextEx(self, font, text, position, fontSize, spacing, t);
     }
 
+    /// Export image data to file, returns true on success
     pub fn exportToFile(self: Image, fileName: [:0]const u8) bool {
         return rl.exportImage(self, fileName);
     }
 
+    /// Export image as code file defining an array of bytes, returns true on success
     pub fn exportAsCode(self: Image, fileName: [:0]const u8) bool {
         return rl.exportImageAsCode(self, fileName);
     }
 
+    /// Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
     pub fn useAsWindowIcon(self: Image) void {
         rl.setWindowIcon(self);
     }
 
+    /// Load texture from image data
     pub fn toTexture(self: Image) Texture {
         return Texture.fromImage(self);
     }
@@ -943,38 +1169,47 @@ pub const Texture = extern struct {
         return rl.loadTexture(fileName);
     }
 
+    /// Load texture from image data
     pub fn fromImage(image: Image) Texture {
         return rl.loadTextureFromImage(image);
     }
 
+    /// Load cubemap from image, multiple image cubemap layouts supported
     pub fn fromCubemap(image: Image, layout: CubemapLayout) Texture {
         return rl.loadTextureCubemap(image, layout);
     }
 
+    /// Unload texture from GPU memory (VRAM)
     pub fn unload(self: Texture) void {
         rl.unloadTexture(self);
     }
 
+    /// Draw a Texture2D
     pub fn draw(self: Texture, posX: i32, posY: i32, tint: Color) void {
         rl.drawTexture(self, posX, posY, tint);
     }
 
+    /// Draw a Texture2D with position defined as Vector2
     pub fn drawV(self: Texture, position: Vector2, tint: Color) void {
         rl.drawTextureV(self, position, tint);
     }
 
+    /// Draw a Texture2D with extended parameters
     pub fn drawEx(self: Texture, position: Vector2, rotation: f32, scale: f32, tint: Color) void {
         rl.drawTextureEx(self, position, rotation, scale, tint);
     }
 
+    /// Draw a part of a texture defined by a rectangle
     pub fn drawRec(self: Texture, source: Rectangle, position: Vector2, tint: Color) void {
         rl.drawTextureRec(self, source, position, tint);
     }
 
+    /// Draw a part of a texture defined by a rectangle with 'pro' parameters
     pub fn drawPro(self: Texture, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
         rl.drawTexturePro(self, source, dest, origin, rotation, tint);
     }
 
+    /// Draws a texture (or part of it) that stretches or shrinks nicely
     pub fn drawNPatch(self: Texture, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
         rl.drawTextureNPatch(self, nPatchInfo, dest, origin, rotation, tint);
     }
@@ -991,14 +1226,17 @@ pub const RenderTexture = extern struct {
         return rl.loadRenderTexture(width, height);
     }
 
+    /// Unload render texture from GPU memory (VRAM)
     pub fn unload(self: RenderTexture) void {
         rl.unloadRenderTexture(self);
     }
 
+    /// Begin drawing to render texture
     pub fn begin(self: RenderTexture2D) void {
         rl.beginTextureMode(self);
     }
 
+    /// Ends drawing to render texture
     pub fn end(_: RenderTexture2D) void {
         rl.endTextureMode();
     }
@@ -1030,30 +1268,37 @@ pub const Font = extern struct {
     recs: [*c]Rectangle,
     glyphs: [*c]GlyphInfo,
 
+    /// Load font from file into GPU memory (VRAM)
     pub fn init(fileName: [:0]const u8) Font {
         return rl.loadFont(fileName);
     }
 
+    /// Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
     pub fn initEx(fileName: [:0]const u8, fontSize: i32, fontChars: []i32) Font {
         return rl.loadFontEx(fileName, fontSize, fontChars);
     }
 
+    /// Load font from Image (XNA style)
     pub fn fromImage(image: Image, key: Color, firstChar: i32) Font {
         return rl.loadFontFromImage(image, key, firstChar);
     }
 
+    /// Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
     pub fn fromMemory(fileType: [:0]const u8, fileData: ?[]const u8, fontSize: i32, fontChars: []i32) Font {
         return rl.loadFontFromMemory(fileType, fileData, fontSize, fontChars);
     }
 
+    /// Unload font from GPU memory (VRAM)
     pub fn unload(self: Font) void {
         rl.unloadFont(self);
     }
 
+    /// Check if a font is ready
     pub fn isReady(self: Font) bool {
         return rl.isFontReady(self);
     }
 
+    /// Export font as code file, returns true on success
     pub fn exportAsCode(self: Font, fileName: [:0]const u8) bool {
         return rl.exportFontAsCode(self, fileName);
     }
@@ -1066,18 +1311,22 @@ pub const Camera3D = extern struct {
     fovy: f32,
     projection: CameraProjection,
 
+    /// Begin 3D mode with camera
     pub fn begin(self: Camera3D) void {
         rl.beginMode3D(self);
     }
 
+    /// Update camera position for selected mode
     pub fn update(self: *Camera3D, mode: rl.CameraMode) void {
         rl.updateCamera(self, mode);
     }
 
+    /// Get camera transform matrix (view matrix)
     pub fn getMatrix(self: Camera3D) Matrix {
         return rl.getCameraMatrix(self);
     }
 
+    /// Ends 3D mode and returns to default 2D orthographic mode
     pub fn end(_: Camera3D) void {
         rl.endMode3D();
     }
@@ -1090,14 +1339,17 @@ pub const Camera2D = extern struct {
     rotation: f32,
     zoom: f32,
 
+    /// Begin 2D mode with camera
     pub fn begin(self: Camera2D) void {
         rl.beginMode2D(self);
     }
 
+    /// Get camera 2d transform matrix
     pub fn getMatrix(self: Camera2D) Matrix {
         return rl.getCameraMatrix2D(self);
     }
 
+    /// Ends 2D mode with camera
     pub fn end(_: Camera2D) void {
         rl.endMode2D();
     }
@@ -1120,10 +1372,12 @@ pub const Mesh = extern struct {
     vaoId: c_uint,
     vboId: [*c]c_uint,
 
+    /// Draw a 3d mesh with material and transform
     pub fn draw(self: Mesh, material: Material, transform: Matrix) void {
         rl.drawMesh(self, material, transform);
     }
 
+    /// Draw multiple mesh instances with material and different transforms
     pub fn drawInstanced(self: Mesh, material: Material, transforms: []const Matrix) void {
         rl.drawMeshInstanced(self, material, transforms);
     }
@@ -1133,10 +1387,12 @@ pub const Shader = extern struct {
     id: c_uint,
     locs: [*c]c_int,
 
+    /// Begin custom shader drawing
     pub fn activate(self: Shader) void {
         rl.beginShaderMode(self);
     }
 
+    /// End custom shader drawing (use default shader)
     pub fn deactivate(_: Shader) void {
         rl.endShaderMode();
     }
@@ -1176,30 +1432,37 @@ pub const Model = extern struct {
     bones: [*c]BoneInfo,
     bindPose: [*c]Transform,
 
+    /// Load model from file (meshes and materials)
     pub fn init(fileName: [:0]const u8) Model {
         return rl.loadModel(fileName);
     }
 
+    /// Load model from generated mesh (default material)
     pub fn fromMesh(mesh: Mesh) Model {
         return rl.loadModelFromMesh(mesh);
     }
 
+    /// Unload model (including meshes) from memory (RAM and/or VRAM)
     pub fn unload(self: Model) void {
         rl.unloadModel(self);
     }
 
+    /// Draw a model (with texture if set)
     pub fn draw(self: Model, position: Vector3, scale: f32, tint: Color) void {
         return rl.drawModel(self, position, scale, tint);
     }
 
+    /// Draw a model with extended parameters
     pub fn drawEx(self: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
         return rl.drawModelEx(self, position, rotationAxis, rotationAngle, scale, tint);
     }
 
+    /// Draw a model wires (with texture if set)
     pub fn drawWires(self: Model, position: Vector3, scale: f32, tint: Color) void {
         return rl.drawModelWires(self, position, scale, tint);
     }
 
+    /// Draw a model wires (with texture if set) with extended parameters
     pub fn drawWiresEx(self: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
         return rl.drawModelWiresEx(self, position, rotationAxis, rotationAngle, scale, tint);
     }
@@ -1298,11 +1561,7 @@ pub const AutomationEvent = extern struct {
     params: [4]c_int,
 };
 
-pub const AutomationEventList = extern struct {
-    capacity: c_uint,
-    count: c_uint,
-    events: [*c]AutomationEvent
-};
+pub const AutomationEventList = extern struct { capacity: c_uint, count: c_uint, events: [*c]AutomationEvent };
 
 pub const ConfigFlags = packed struct {
     __reserved: bool = false,
@@ -1704,10 +1963,12 @@ pub const SHADER_LOC_MAP_SPECULAR = ShaderLocationIndex.shader_loc_map_metalness
 
 const cdef = @import("raylib-ext.zig");
 
+/// Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
 pub fn setWindowIcons(images: []Image) void {
     cdef.SetWindowIcons(@as([*c]Image, @ptrCast(images)), @as(c_int, @intCast(images.len)));
 }
 
+/// Load shader from files and bind default locations
 pub fn loadShader(vsFileName: ?[:0]const u8, fsFileName: ?[:0]const u8) Shader {
     var vsFileNameFinal = @as([*c]const u8, 0);
     var fsFileNameFinal = @as([*c]const u8, 0);
@@ -1720,6 +1981,7 @@ pub fn loadShader(vsFileName: ?[:0]const u8, fsFileName: ?[:0]const u8) Shader {
     return cdef.LoadShader(vsFileNameFinal, fsFileNameFinal);
 }
 
+/// Load shader from code strings and bind default locations
 pub fn loadShaderFromMemory(vsCode: ?[:0]const u8, fsCode: ?[:0]const u8) Shader {
     var vsCodeFinal = @as([*c]const u8, 0);
     var fsCodeFinal = @as([*c]const u8, 0);
@@ -1732,6 +1994,7 @@ pub fn loadShaderFromMemory(vsCode: ?[:0]const u8, fsCode: ?[:0]const u8) Shader
     return cdef.LoadShaderFromMemory(vsCodeFinal, fsCodeFinal);
 }
 
+/// Load file data as byte array (read)
 pub fn loadFileData(fileName: [:0]const u8) RaylibError![]u8 {
     var bytesRead: i32 = 0;
     var res: []u8 = undefined;
@@ -1744,14 +2007,17 @@ pub fn loadFileData(fileName: [:0]const u8) RaylibError![]u8 {
     return res;
 }
 
+/// Save data to file from byte array (write), returns true on success
 pub fn saveFileData(fileName: [:0]const u8, data: []u8) bool {
     return cdef.SaveFileData(@as([*c]const u8, @ptrCast(fileName)), @as(*anyopaque, @ptrCast(data.ptr)), @as(c_int, @intCast(data.len)));
 }
 
+/// Export data to code (.h), returns true on success
 pub fn exportDataAsCode(data: []const u8, fileName: [:0]const u8) bool {
     return cdef.ExportDataAsCode(@as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)), @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Compress data (DEFLATE algorithm), memory must be MemFree()
 pub fn compressData(data: []const u8) []u8 {
     var compDataSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1760,6 +2026,7 @@ pub fn compressData(data: []const u8) []u8 {
     return res;
 }
 
+/// Decompress data (DEFLATE algorithm), memory must be MemFree()
 pub fn decompressData(compData: []const u8) []u8 {
     var dataSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1768,6 +2035,7 @@ pub fn decompressData(compData: []const u8) []u8 {
     return res;
 }
 
+/// Encode data to Base64 string, memory must be MemFree()
 pub fn encodeDataBase64(data: []const u8) []u8 {
     var outputSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1776,6 +2044,7 @@ pub fn encodeDataBase64(data: []const u8) []u8 {
     return res;
 }
 
+/// Decode Base64 string data, memory must be MemFree()
 pub fn decodeDataBase64(data: []const u8) []u8 {
     var outputSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1788,10 +2057,12 @@ pub fn loadImageAnimFromMemory(fileType: [:0]const u8, fileData: []const u8, fra
     return cdef.LoadImageAnimFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileData)), @as(c_int, @intCast(fileData.len)), @as([*c]c_int, @ptrCast(frames)));
 }
 
+/// Load image from memory buffer, fileType refers to extension: i.e. '.png'
 pub fn loadImageFromMemory(fileType: [:0]const u8, fileData: []const u8) Image {
     return cdef.LoadImageFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileData)), @as(c_int, @intCast(fileData.len)));
 }
 
+/// Load color data from image as a Color array (RGBA - 32bit)
 pub fn loadImageColors(image: Image) RaylibError![]Color {
     var res: []Color = undefined;
 
@@ -1803,6 +2074,7 @@ pub fn loadImageColors(image: Image) RaylibError![]Color {
     return res;
 }
 
+/// Load colors palette from image as a Color array (RGBA - 32bit)
 pub fn loadImagePalette(image: Image, maxPaletteSize: i32) RaylibError![]Color {
     var colorCount: i32 = 0;
     var res: []Color = undefined;
@@ -1815,6 +2087,8 @@ pub fn loadImagePalette(image: Image, maxPaletteSize: i32) RaylibError![]Color {
     return res;
 }
 
+/// Load font from file with extended parameters, use null for codepoints and 0
+/// for codepointCount to load the default character set
 pub fn loadFontEx(fileName: [:0]const u8, fontSize: i32, fontChars: ?[]i32) Font {
     var fontCharsFinal = @as([*c]c_int, 0);
     var fontCharsLen: c_int = @as(c_int, 0);
@@ -1825,6 +2099,7 @@ pub fn loadFontEx(fileName: [:0]const u8, fontSize: i32, fontChars: ?[]i32) Font
     return cdef.LoadFontEx(@as([*c]const u8, @ptrCast(fileName)), @as(c_int, fontSize), fontCharsFinal, fontCharsLen);
 }
 
+/// Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
 pub fn loadFontFromMemory(fileType: [:0]const u8, fileData: ?[]const u8, fontSize: i32, fontChars: []i32) Font {
     var fileDataFinal = @as([*c]const u8, 0);
     var fileDataLen: i32 = 0;
@@ -1835,6 +2110,7 @@ pub fn loadFontFromMemory(fileType: [:0]const u8, fileData: ?[]const u8, fontSiz
     return cdef.LoadFontFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileDataFinal)), @as(c_int, @intCast(fileDataLen)), @as(c_int, fontSize), @as([*c]c_int, @ptrCast(fontChars)), @as(c_int, @intCast(fontChars.len)));
 }
 
+/// Load font data for further use
 pub fn loadFontData(fileData: []const u8, fontSize: i32, fontChars: []i32, ty: FontType) RaylibError![]GlyphInfo {
     var res: []GlyphInfo = undefined;
 
@@ -1846,6 +2122,7 @@ pub fn loadFontData(fileData: []const u8, fontSize: i32, fontChars: []i32, ty: F
     return res;
 }
 
+/// Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
 pub fn loadCodepoints(text: [:0]const u8) RaylibError![]i32 {
     if (@sizeOf(c_int) != @sizeOf(i32)) {
         @compileError("Can't cast pointer to c_int array to i32 because they don't have the same size");
@@ -1861,6 +2138,7 @@ pub fn loadCodepoints(text: [:0]const u8) RaylibError![]i32 {
     return res;
 }
 
+/// Text formatting with variables (sprintf() style)
 pub fn textFormat(text: [:0]const u8, args: anytype) [:0]const u8 {
     comptime {
         const info = @typeInfo(@TypeOf(args));
@@ -1871,13 +2149,14 @@ pub fn textFormat(text: [:0]const u8, args: anytype) [:0]const u8 {
             },
             else => {
                 @compileError("Args should be in a tuple (call this function like textFormat(.{arg1, arg2, ...});)!");
-            }
+            },
         }
     }
 
     return std.mem.span(@call(.auto, cdef.TextFormat, .{@as([*c]const u8, @ptrCast(text))} ++ args));
 }
 
+/// Split text into multiple strings
 pub fn textSplit(text: [:0]const u8, delimiter: u8) [][:0]const u8 {
     var count: i32 = 0;
     var res: [][:0]const u8 = undefined;
@@ -1886,10 +2165,12 @@ pub fn textSplit(text: [:0]const u8, delimiter: u8) [][:0]const u8 {
     return res;
 }
 
+/// Draw multiple mesh instances with material and different transforms
 pub fn drawMeshInstanced(mesh: Mesh, material: Material, transforms: []const Matrix) void {
     cdef.DrawMeshInstanced(mesh, material, @as([*c]const Matrix, @ptrCast(transforms)), @as(c_int, @intCast(transforms.len)));
 }
 
+/// Load materials from model file
 pub fn loadMaterials(fileName: [:0]const u8) RaylibError![]Material {
     var materialCount: i32 = 0;
     var res: []Material = undefined;
@@ -1902,6 +2183,7 @@ pub fn loadMaterials(fileName: [:0]const u8) RaylibError![]Material {
     return res;
 }
 
+/// Load model animations from file
 pub fn loadModelAnimations(fileName: [:0]const u8) RaylibError![]ModelAnimation {
     var animCount: i32 = 0;
     var res: []ModelAnimation = undefined;
@@ -1914,14 +2196,17 @@ pub fn loadModelAnimations(fileName: [:0]const u8) RaylibError![]ModelAnimation 
     return res;
 }
 
+/// Unload animation data
 pub fn unloadModelAnimations(animations: []ModelAnimation) void {
     cdef.UnloadModelAnimations(@as([*c]ModelAnimation, @ptrCast(animations)), @as(c_int, @intCast(animations.len)));
 }
 
+/// Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
 pub fn loadWaveFromMemory(fileType: [:0]const u8, fileData: []const u8) Wave {
     return cdef.LoadWaveFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileData)), @as(c_int, @intCast(fileData.len)));
 }
 
+/// Load samples data from wave as a 32bit float data array
 pub fn loadWaveSamples(wave: Wave) []f32 {
     var res: []f32 = undefined;
     res.ptr = @as([*]f32, @ptrCast(cdef.LoadWaveSamples(wave)));
@@ -1929,46 +2214,57 @@ pub fn loadWaveSamples(wave: Wave) []f32 {
     return res;
 }
 
+/// Load music stream from data
 pub fn loadMusicStreamFromMemory(fileType: [:0]const u8, data: []const u8) Music {
     return cdef.LoadMusicStreamFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)));
 }
 
+/// Draw lines sequence (using gl lines)
 pub fn drawLineStrip(points: []Vector2, color: Color) void {
     cdef.DrawLineStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Draw a triangle fan defined by points (first vertex is the center)
 pub fn drawTriangleFan(points: []Vector2, color: Color) void {
     cdef.DrawTriangleFan(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Draw a triangle strip defined by points
 pub fn drawTriangleStrip(points: []Vector2, color: Color) void {
     cdef.DrawTriangleStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Check if point is within a polygon described by array of vertices
 pub fn checkCollisionPointPoly(point: Vector2, points: []Vector2) bool {
     return cdef.CheckCollisionPointPoly(point, @as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
 }
 
+/// Generate image font atlas using chars info
 pub fn genImageFontAtlas(chars: []const GlyphInfo, recs: [][]Rectangle, fontSize: i32, padding: i32, packMethod: i32) Image {
     return cdef.GenImageFontAtlas(@as([*c]const GlyphInfo, @ptrCast(chars)), @as([*c][*c]Rectangle, @ptrCast(recs)), @as(c_int, @intCast(recs.len)), @as(c_int, fontSize), @as(c_int, padding), @as(c_int, packMethod));
 }
 
+/// Unload font chars info data (RAM)
 pub fn unloadFontData(chars: []GlyphInfo) void {
     cdef.UnloadFontData(@as([*c]GlyphInfo, @ptrCast(chars)), @as(c_int, @intCast(chars.len)));
 }
 
+/// Load UTF-8 text encoded from codepoints array
 pub fn loadUTF8(codepoints: []const c_int) [:0]u8 {
     return std.mem.span(cdef.LoadUTF8(@as([*c]const c_int, @ptrCast(codepoints)), @as(c_int, @intCast(codepoints.len))));
 }
 
+/// Join text strings with delimiter
 pub fn textJoin(textList: [][:0]const u8, delimiter: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextJoin(@as([*c][*c]const u8, @ptrCast(textList)), @as(c_int, @intCast(textList.len)), @as([*c]const u8, @ptrCast(delimiter))));
 }
 
+/// Draw a triangle strip defined by points
 pub fn drawTriangleStrip3D(points: []Vector3, color: Color) void {
     cdef.DrawTriangleStrip3D(@as([*c]Vector3, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Internal memory allocator
 fn alloc(_: *anyopaque, len: usize, _: u8, _: usize) ?[*]u8 {
     std.debug.assert(len > 0);
     return @ptrCast(cdef.MemAlloc(@intCast(len)));
@@ -1978,6 +2274,7 @@ fn resize(_: *anyopaque, buf: []u8, _: u8, new_len: usize, _: usize) bool {
     return (new_len <= buf.len);
 }
 
+/// Internal memory free
 fn free(_: *anyopaque, buf: []u8, _: u8, _: usize) void {
     cdef.MemFree(buf.ptr);
 }

--- a/lib/raygui.zig
+++ b/lib/raygui.zig
@@ -458,206 +458,257 @@ pub fn guiScrollPanel(bounds: Rectangle, text: ?[:0]const u8, content: Rectangle
     return @as(i32, cdef.GuiScrollPanel(bounds, textFinal, content, @as([*c]Vector2, @ptrCast(scroll)), @as([*c]Rectangle, @ptrCast(view))));
 }
 
+/// Enable gui controls (global state)
 pub fn guiEnable() void {
     cdef.GuiEnable();
 }
 
+/// Disable gui controls (global state)
 pub fn guiDisable() void {
     cdef.GuiDisable();
 }
 
+/// Lock gui controls (global state)
 pub fn guiLock() void {
     cdef.GuiLock();
 }
 
+/// Unlock gui controls (global state)
 pub fn guiUnlock() void {
     cdef.GuiUnlock();
 }
 
+/// Check if gui is locked (global state)
 pub fn guiIsLocked() bool {
     return cdef.GuiIsLocked();
 }
 
+/// Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
 pub fn guiSetAlpha(alpha: f32) void {
     cdef.GuiSetAlpha(alpha);
 }
 
+/// Set gui state (global state)
 pub fn guiSetState(state: i32) void {
     cdef.GuiSetState(@as(c_int, state));
 }
 
+/// Get gui state (global state)
 pub fn guiGetState() i32 {
     return @as(i32, cdef.GuiGetState());
 }
 
+/// Set gui custom font (global state)
 pub fn guiSetFont(font: Font) void {
     cdef.GuiSetFont(font);
 }
 
+/// Get gui custom font (global state)
 pub fn guiGetFont() Font {
     return cdef.GuiGetFont();
 }
 
+/// Set one style property
 pub fn guiSetStyle(control: i32, property: i32, value: i32) void {
     cdef.GuiSetStyle(@as(c_int, control), @as(c_int, property), @as(c_int, value));
 }
 
+/// Get one style property
 pub fn guiGetStyle(control: i32, property: i32) i32 {
     return @as(i32, cdef.GuiGetStyle(@as(c_int, control), @as(c_int, property)));
 }
 
+/// Load style file over global style variable (.rgs)
 pub fn guiLoadStyle(fileName: [:0]const u8) void {
     cdef.GuiLoadStyle(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load style default over global style
 pub fn guiLoadStyleDefault() void {
     cdef.GuiLoadStyleDefault();
 }
 
+/// Enable gui tooltips (global state)
 pub fn guiEnableTooltip() void {
     cdef.GuiEnableTooltip();
 }
 
+/// Disable gui tooltips (global state)
 pub fn guiDisableTooltip() void {
     cdef.GuiDisableTooltip();
 }
 
+/// Set tooltip string
 pub fn guiSetTooltip(tooltip: [:0]const u8) void {
     cdef.GuiSetTooltip(@as([*c]const u8, @ptrCast(tooltip)));
 }
 
+/// Get text with icon id prepended (if supported)
 pub fn guiIconText(iconId: i32, text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GuiIconText(@as(c_int, iconId), @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Set default icon drawing size
 pub fn guiSetIconScale(scale: i32) void {
     cdef.GuiSetIconScale(@as(c_int, scale));
 }
 
+/// Draw icon using pixel size at specified position
 pub fn guiDrawIcon(iconId: i32, posX: i32, posY: i32, pixelSize: i32, color: Color) void {
     cdef.GuiDrawIcon(@as(c_int, iconId), @as(c_int, posX), @as(c_int, posY), @as(c_int, pixelSize), color);
 }
 
+/// Window Box control, shows a window that can be closed
 pub fn guiWindowBox(bounds: Rectangle, title: [:0]const u8) i32 {
     return @as(i32, cdef.GuiWindowBox(bounds, @as([*c]const u8, @ptrCast(title))));
 }
 
+/// Group Box control with text name
 pub fn guiGroupBox(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiGroupBox(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Line separator control, could contain text
 pub fn guiLine(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLine(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Label control
 pub fn guiLabel(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLabel(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Button control, returns true when clicked
 pub fn guiButton(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiButton(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Label button control, returns true when clicked
 pub fn guiLabelButton(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLabelButton(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Toggle Button control
 pub fn guiToggle(bounds: Rectangle, text: [:0]const u8, active: *bool) i32 {
     return @as(i32, cdef.GuiToggle(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]bool, @ptrCast(active))));
 }
 
+/// Toggle Group control
 pub fn guiToggleGroup(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiToggleGroup(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Toggle Slider control
 pub fn guiToggleSlider(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiToggleSlider(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Check Box control, returns true when active
 pub fn guiCheckBox(bounds: Rectangle, text: [:0]const u8, checked: *bool) i32 {
     return @as(i32, cdef.GuiCheckBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]bool, @ptrCast(checked))));
 }
 
+/// Combo Box control
 pub fn guiComboBox(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiComboBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Dropdown Box control
 pub fn guiDropdownBox(bounds: Rectangle, text: [:0]const u8, active: *i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiDropdownBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active)), editMode));
 }
 
+/// Spinner control
 pub fn guiSpinner(bounds: Rectangle, text: [:0]const u8, value: *i32, minValue: i32, maxValue: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiSpinner(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(value)), @as(c_int, minValue), @as(c_int, maxValue), editMode));
 }
 
+/// Value Box control, updates input text with numbers
 pub fn guiValueBox(bounds: Rectangle, text: [:0]const u8, value: *i32, minValue: i32, maxValue: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiValueBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(value)), @as(c_int, minValue), @as(c_int, maxValue), editMode));
 }
 
+/// Value box control for float values
 pub fn guiValueBoxFloat(bounds: Rectangle, text: [:0]const u8, textValue: [:0]u8, value: *f32, editMode: bool) i32 {
     return @as(i32, cdef.GuiValueBoxFloat(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]u8, @ptrCast(textValue)), @as([*c]f32, @ptrCast(value)), editMode));
 }
 
+/// Text Box control, updates input text
 pub fn guiTextBox(bounds: Rectangle, text: [:0]u8, textSize: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiTextBox(bounds, @as([*c]u8, @ptrCast(text)), @as(c_int, textSize), editMode));
 }
 
+/// Slider control
 pub fn guiSlider(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiSlider(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
+/// Slider Bar control
 pub fn guiSliderBar(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiSliderBar(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
+/// Progress Bar control
 pub fn guiProgressBar(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiProgressBar(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
+/// Status Bar control, shows info text
 pub fn guiStatusBar(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiStatusBar(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Dummy control for placeholders
 pub fn guiDummyRec(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiDummyRec(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Grid control
 pub fn guiGrid(bounds: Rectangle, text: [:0]const u8, spacing: f32, subdivs: i32, mouseCell: *Vector2) i32 {
     return @as(i32, cdef.GuiGrid(bounds, @as([*c]const u8, @ptrCast(text)), spacing, @as(c_int, subdivs), @as([*c]Vector2, @ptrCast(mouseCell))));
 }
 
+/// List View control
 pub fn guiListView(bounds: Rectangle, text: [:0]const u8, scrollIndex: *i32, active: *i32) i32 {
     return @as(i32, cdef.GuiListView(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(scrollIndex)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Message Box control, displays a message
 pub fn guiMessageBox(bounds: Rectangle, title: [:0]const u8, message: [:0]const u8, buttons: [:0]const u8) i32 {
     return @as(i32, cdef.GuiMessageBox(bounds, @as([*c]const u8, @ptrCast(title)), @as([*c]const u8, @ptrCast(message)), @as([*c]const u8, @ptrCast(buttons))));
 }
 
+/// Text Input Box control, ask for text, supports secret
 pub fn guiTextInputBox(bounds: Rectangle, title: [:0]const u8, message: [:0]const u8, buttons: [:0]const u8, text: [:0]u8, textMaxSize: i32, secretViewActive: *bool) i32 {
     return @as(i32, cdef.GuiTextInputBox(bounds, @as([*c]const u8, @ptrCast(title)), @as([*c]const u8, @ptrCast(message)), @as([*c]const u8, @ptrCast(buttons)), @as([*c]u8, @ptrCast(text)), @as(c_int, textMaxSize), @as([*c]bool, @ptrCast(secretViewActive))));
 }
 
+/// Color Picker control (multiple color controls)
 pub fn guiColorPicker(bounds: Rectangle, text: [:0]const u8, color: *Color) i32 {
     return @as(i32, cdef.GuiColorPicker(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Color, @ptrCast(color))));
 }
 
+/// Color Panel control
 pub fn guiColorPanel(bounds: Rectangle, text: [:0]const u8, color: *Color) i32 {
     return @as(i32, cdef.GuiColorPanel(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Color, @ptrCast(color))));
 }
 
+/// Color Bar Alpha control
 pub fn guiColorBarAlpha(bounds: Rectangle, text: [:0]const u8, alpha: *f32) i32 {
     return @as(i32, cdef.GuiColorBarAlpha(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]f32, @ptrCast(alpha))));
 }
 
+/// Color Bar Hue control
 pub fn guiColorBarHue(bounds: Rectangle, text: [:0]const u8, value: *f32) i32 {
     return @as(i32, cdef.GuiColorBarHue(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]f32, @ptrCast(value))));
 }
 
+/// Color Picker control that avoids conversion to RGB on each call (multiple color controls)
 pub fn guiColorPickerHSV(bounds: Rectangle, text: [:0]const u8, colorHsv: *Vector3) i32 {
     return @as(i32, cdef.GuiColorPickerHSV(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Vector3, @ptrCast(colorHsv))));
 }
 
+/// Color Panel control that updates Hue-Saturation-Value color value, used by GuiColorPickerHSV()
 pub fn guiColorPanelHSV(bounds: Rectangle, text: [:0]const u8, colorHsv: *Vector3) i32 {
     return @as(i32, cdef.GuiColorPanelHSV(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Vector3, @ptrCast(colorHsv))));
 }

--- a/lib/raygui.zig
+++ b/lib/raygui.zig
@@ -452,206 +452,257 @@ pub fn guiScrollPanel(bounds: Rectangle, text: ?[:0]const u8, content: Rectangle
     return @as(i32, cdef.GuiScrollPanel(bounds, textFinal, content, @as([*c]Vector2, @ptrCast(scroll)), @as([*c]Rectangle, @ptrCast(view))));
 }
 
+/// Enable gui controls (global state)
 pub fn guiEnable() void {
     cdef.GuiEnable();
 }
 
+/// Disable gui controls (global state)
 pub fn guiDisable() void {
     cdef.GuiDisable();
 }
 
+/// Lock gui controls (global state)
 pub fn guiLock() void {
     cdef.GuiLock();
 }
 
+/// Unlock gui controls (global state)
 pub fn guiUnlock() void {
     cdef.GuiUnlock();
 }
 
+/// Check if gui is locked (global state)
 pub fn guiIsLocked() bool {
     return cdef.GuiIsLocked();
 }
 
+/// Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
 pub fn guiSetAlpha(alpha: f32) void {
     cdef.GuiSetAlpha(alpha);
 }
 
+/// Set gui state (global state)
 pub fn guiSetState(state: i32) void {
     cdef.GuiSetState(@as(c_int, state));
 }
 
+/// Get gui state (global state)
 pub fn guiGetState() i32 {
     return @as(i32, cdef.GuiGetState());
 }
 
+/// Set gui custom font (global state)
 pub fn guiSetFont(font: Font) void {
     cdef.GuiSetFont(font);
 }
 
+/// Get gui custom font (global state)
 pub fn guiGetFont() Font {
     return cdef.GuiGetFont();
 }
 
+/// Set one style property
 pub fn guiSetStyle(control: i32, property: i32, value: i32) void {
     cdef.GuiSetStyle(@as(c_int, control), @as(c_int, property), @as(c_int, value));
 }
 
+/// Get one style property
 pub fn guiGetStyle(control: i32, property: i32) i32 {
     return @as(i32, cdef.GuiGetStyle(@as(c_int, control), @as(c_int, property)));
 }
 
+/// Load style file over global style variable (.rgs)
 pub fn guiLoadStyle(fileName: [:0]const u8) void {
     cdef.GuiLoadStyle(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load style default over global style
 pub fn guiLoadStyleDefault() void {
     cdef.GuiLoadStyleDefault();
 }
 
+/// Enable gui tooltips (global state)
 pub fn guiEnableTooltip() void {
     cdef.GuiEnableTooltip();
 }
 
+/// Disable gui tooltips (global state)
 pub fn guiDisableTooltip() void {
     cdef.GuiDisableTooltip();
 }
 
+/// Set tooltip string
 pub fn guiSetTooltip(tooltip: [:0]const u8) void {
     cdef.GuiSetTooltip(@as([*c]const u8, @ptrCast(tooltip)));
 }
 
+/// Get text with icon id prepended (if supported)
 pub fn guiIconText(iconId: i32, text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GuiIconText(@as(c_int, iconId), @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Set default icon drawing size
 pub fn guiSetIconScale(scale: i32) void {
     cdef.GuiSetIconScale(@as(c_int, scale));
 }
 
+/// Draw icon using pixel size at specified position
 pub fn guiDrawIcon(iconId: i32, posX: i32, posY: i32, pixelSize: i32, color: Color) void {
     cdef.GuiDrawIcon(@as(c_int, iconId), @as(c_int, posX), @as(c_int, posY), @as(c_int, pixelSize), color);
 }
 
+/// Window Box control, shows a window that can be closed
 pub fn guiWindowBox(bounds: Rectangle, title: [:0]const u8) i32 {
     return @as(i32, cdef.GuiWindowBox(bounds, @as([*c]const u8, @ptrCast(title))));
 }
 
+/// Group Box control with text name
 pub fn guiGroupBox(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiGroupBox(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Line separator control, could contain text
 pub fn guiLine(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLine(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Label control
 pub fn guiLabel(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLabel(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Button control, returns true when clicked
 pub fn guiButton(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiButton(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Label button control, returns true when clicked
 pub fn guiLabelButton(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLabelButton(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Toggle Button control
 pub fn guiToggle(bounds: Rectangle, text: [:0]const u8, active: *bool) i32 {
     return @as(i32, cdef.GuiToggle(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]bool, @ptrCast(active))));
 }
 
+/// Toggle Group control
 pub fn guiToggleGroup(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiToggleGroup(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Toggle Slider control
 pub fn guiToggleSlider(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiToggleSlider(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Check Box control, returns true when active
 pub fn guiCheckBox(bounds: Rectangle, text: [:0]const u8, checked: *bool) i32 {
     return @as(i32, cdef.GuiCheckBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]bool, @ptrCast(checked))));
 }
 
+/// Combo Box control
 pub fn guiComboBox(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiComboBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Dropdown Box control
 pub fn guiDropdownBox(bounds: Rectangle, text: [:0]const u8, active: *i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiDropdownBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active)), editMode));
 }
 
+/// Spinner control
 pub fn guiSpinner(bounds: Rectangle, text: [:0]const u8, value: *i32, minValue: i32, maxValue: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiSpinner(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(value)), @as(c_int, minValue), @as(c_int, maxValue), editMode));
 }
 
+/// Value Box control, updates input text with numbers
 pub fn guiValueBox(bounds: Rectangle, text: [:0]const u8, value: *i32, minValue: i32, maxValue: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiValueBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(value)), @as(c_int, minValue), @as(c_int, maxValue), editMode));
 }
 
+/// Value box control for float values
 pub fn guiValueBoxFloat(bounds: Rectangle, text: [:0]const u8, textValue: [:0]u8, value: *f32, editMode: bool) i32 {
     return @as(i32, cdef.GuiValueBoxFloat(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]u8, @ptrCast(textValue)), @as([*c]f32, @ptrCast(value)), editMode));
 }
 
+/// Text Box control, updates input text
 pub fn guiTextBox(bounds: Rectangle, text: [:0]u8, textSize: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiTextBox(bounds, @as([*c]u8, @ptrCast(text)), @as(c_int, textSize), editMode));
 }
 
+/// Slider control
 pub fn guiSlider(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiSlider(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
+/// Slider Bar control
 pub fn guiSliderBar(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiSliderBar(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
+/// Progress Bar control
 pub fn guiProgressBar(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiProgressBar(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
+/// Status Bar control, shows info text
 pub fn guiStatusBar(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiStatusBar(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Dummy control for placeholders
 pub fn guiDummyRec(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiDummyRec(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
+/// Grid control
 pub fn guiGrid(bounds: Rectangle, text: [:0]const u8, spacing: f32, subdivs: i32, mouseCell: *Vector2) i32 {
     return @as(i32, cdef.GuiGrid(bounds, @as([*c]const u8, @ptrCast(text)), spacing, @as(c_int, subdivs), @as([*c]Vector2, @ptrCast(mouseCell))));
 }
 
+/// List View control
 pub fn guiListView(bounds: Rectangle, text: [:0]const u8, scrollIndex: *i32, active: *i32) i32 {
     return @as(i32, cdef.GuiListView(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(scrollIndex)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// Message Box control, displays a message
 pub fn guiMessageBox(bounds: Rectangle, title: [:0]const u8, message: [:0]const u8, buttons: [:0]const u8) i32 {
     return @as(i32, cdef.GuiMessageBox(bounds, @as([*c]const u8, @ptrCast(title)), @as([*c]const u8, @ptrCast(message)), @as([*c]const u8, @ptrCast(buttons))));
 }
 
+/// Text Input Box control, ask for text, supports secret
 pub fn guiTextInputBox(bounds: Rectangle, title: [:0]const u8, message: [:0]const u8, buttons: [:0]const u8, text: [:0]u8, textMaxSize: i32, secretViewActive: *bool) i32 {
     return @as(i32, cdef.GuiTextInputBox(bounds, @as([*c]const u8, @ptrCast(title)), @as([*c]const u8, @ptrCast(message)), @as([*c]const u8, @ptrCast(buttons)), @as([*c]u8, @ptrCast(text)), @as(c_int, textMaxSize), @as([*c]bool, @ptrCast(secretViewActive))));
 }
 
+/// Color Picker control (multiple color controls)
 pub fn guiColorPicker(bounds: Rectangle, text: [:0]const u8, color: *Color) i32 {
     return @as(i32, cdef.GuiColorPicker(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Color, @ptrCast(color))));
 }
 
+/// Color Panel control
 pub fn guiColorPanel(bounds: Rectangle, text: [:0]const u8, color: *Color) i32 {
     return @as(i32, cdef.GuiColorPanel(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Color, @ptrCast(color))));
 }
 
+/// Color Bar Alpha control
 pub fn guiColorBarAlpha(bounds: Rectangle, text: [:0]const u8, alpha: *f32) i32 {
     return @as(i32, cdef.GuiColorBarAlpha(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]f32, @ptrCast(alpha))));
 }
 
+/// Color Bar Hue control
 pub fn guiColorBarHue(bounds: Rectangle, text: [:0]const u8, value: *f32) i32 {
     return @as(i32, cdef.GuiColorBarHue(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]f32, @ptrCast(value))));
 }
 
+/// Color Picker control that avoids conversion to RGB on each call (multiple color controls)
 pub fn guiColorPickerHSV(bounds: Rectangle, text: [:0]const u8, colorHsv: *Vector3) i32 {
     return @as(i32, cdef.GuiColorPickerHSV(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Vector3, @ptrCast(colorHsv))));
 }
 
+/// Color Panel control that updates Hue-Saturation-Value color value, used by GuiColorPickerHSV()
 pub fn guiColorPanelHSV(bounds: Rectangle, text: [:0]const u8, colorHsv: *Vector3) i32 {
     return @as(i32, cdef.GuiColorPanelHSV(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Vector3, @ptrCast(colorHsv))));
 }

--- a/lib/raygui.zig
+++ b/lib/raygui.zig
@@ -412,6 +412,7 @@ pub const GuiIconName = enum(c_int) {
     icon_255 = 255,
 };
 
+/// Get raygui icons data pointer
 pub fn guiGetIcons() rl.RaylibError![]u32 {
     var res: []u32 = undefined;
 
@@ -424,18 +425,22 @@ pub fn guiGetIcons() rl.RaylibError![]u32 {
 }
 
 // If you REALLY need the return value of the function, you'll know what to do with it and its size yourself
+/// Load raygui icons file (.rgi) into internal icons data
 pub fn guiLoadIcons(fileName: [*c]const u8, loadIconsName: bool) [*c][*c]u8 {
     return cdef.GuiLoadIcons(fileName, loadIconsName);
 }
 
+/// Tab Bar control, returns TAB to be closed or -1
 pub fn guiTabBar(bounds: Rectangle, text: [][:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiTabBar(bounds, @as([*c][*c]const u8, @ptrCast(text)), @as(c_int, @intCast(text.len)), @as([*c]c_int, @ptrCast(active))));
 }
 
+/// List View with extended parameters
 pub fn guiListViewEx(bounds: Rectangle, text: [][:0]const u8, scrollIndex: *i32, active: *i32, focus: *i32) i32 {
     return @as(i32, cdef.GuiListViewEx(bounds, @as([*c][*c]const u8, @ptrCast(text)), @as(c_int, @intCast(text.len)), @as([*c]c_int, @ptrCast(scrollIndex)), @as([*c]c_int, @ptrCast(active)), @as([*c]c_int, @ptrCast(focus))));
 }
 
+/// Panel control, useful to group controls
 pub fn guiPanel(bounds: Rectangle, text: ?[:0]const u8) i32 {
     var textFinal = @as([*c]const u8, 0);
     if (text) |textSure| {
@@ -444,6 +449,7 @@ pub fn guiPanel(bounds: Rectangle, text: ?[:0]const u8) i32 {
     return @as(i32, cdef.GuiPanel(bounds, textFinal));
 }
 
+/// Scroll Panel control
 pub fn guiScrollPanel(bounds: Rectangle, text: ?[:0]const u8, content: Rectangle, scroll: *Vector2, view: *Rectangle) i32 {
     var textFinal = @as([*c]const u8, 0);
     if (text) |textSure| {
@@ -452,257 +458,206 @@ pub fn guiScrollPanel(bounds: Rectangle, text: ?[:0]const u8, content: Rectangle
     return @as(i32, cdef.GuiScrollPanel(bounds, textFinal, content, @as([*c]Vector2, @ptrCast(scroll)), @as([*c]Rectangle, @ptrCast(view))));
 }
 
-/// Enable gui controls (global state)
 pub fn guiEnable() void {
     cdef.GuiEnable();
 }
 
-/// Disable gui controls (global state)
 pub fn guiDisable() void {
     cdef.GuiDisable();
 }
 
-/// Lock gui controls (global state)
 pub fn guiLock() void {
     cdef.GuiLock();
 }
 
-/// Unlock gui controls (global state)
 pub fn guiUnlock() void {
     cdef.GuiUnlock();
 }
 
-/// Check if gui is locked (global state)
 pub fn guiIsLocked() bool {
     return cdef.GuiIsLocked();
 }
 
-/// Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
 pub fn guiSetAlpha(alpha: f32) void {
     cdef.GuiSetAlpha(alpha);
 }
 
-/// Set gui state (global state)
 pub fn guiSetState(state: i32) void {
     cdef.GuiSetState(@as(c_int, state));
 }
 
-/// Get gui state (global state)
 pub fn guiGetState() i32 {
     return @as(i32, cdef.GuiGetState());
 }
 
-/// Set gui custom font (global state)
 pub fn guiSetFont(font: Font) void {
     cdef.GuiSetFont(font);
 }
 
-/// Get gui custom font (global state)
 pub fn guiGetFont() Font {
     return cdef.GuiGetFont();
 }
 
-/// Set one style property
 pub fn guiSetStyle(control: i32, property: i32, value: i32) void {
     cdef.GuiSetStyle(@as(c_int, control), @as(c_int, property), @as(c_int, value));
 }
 
-/// Get one style property
 pub fn guiGetStyle(control: i32, property: i32) i32 {
     return @as(i32, cdef.GuiGetStyle(@as(c_int, control), @as(c_int, property)));
 }
 
-/// Load style file over global style variable (.rgs)
 pub fn guiLoadStyle(fileName: [:0]const u8) void {
     cdef.GuiLoadStyle(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load style default over global style
 pub fn guiLoadStyleDefault() void {
     cdef.GuiLoadStyleDefault();
 }
 
-/// Enable gui tooltips (global state)
 pub fn guiEnableTooltip() void {
     cdef.GuiEnableTooltip();
 }
 
-/// Disable gui tooltips (global state)
 pub fn guiDisableTooltip() void {
     cdef.GuiDisableTooltip();
 }
 
-/// Set tooltip string
 pub fn guiSetTooltip(tooltip: [:0]const u8) void {
     cdef.GuiSetTooltip(@as([*c]const u8, @ptrCast(tooltip)));
 }
 
-/// Get text with icon id prepended (if supported)
 pub fn guiIconText(iconId: i32, text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GuiIconText(@as(c_int, iconId), @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Set default icon drawing size
 pub fn guiSetIconScale(scale: i32) void {
     cdef.GuiSetIconScale(@as(c_int, scale));
 }
 
-/// Draw icon using pixel size at specified position
 pub fn guiDrawIcon(iconId: i32, posX: i32, posY: i32, pixelSize: i32, color: Color) void {
     cdef.GuiDrawIcon(@as(c_int, iconId), @as(c_int, posX), @as(c_int, posY), @as(c_int, pixelSize), color);
 }
 
-/// Window Box control, shows a window that can be closed
 pub fn guiWindowBox(bounds: Rectangle, title: [:0]const u8) i32 {
     return @as(i32, cdef.GuiWindowBox(bounds, @as([*c]const u8, @ptrCast(title))));
 }
 
-/// Group Box control with text name
 pub fn guiGroupBox(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiGroupBox(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Line separator control, could contain text
 pub fn guiLine(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLine(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Label control
 pub fn guiLabel(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLabel(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Button control, returns true when clicked
 pub fn guiButton(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiButton(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Label button control, returns true when clicked
 pub fn guiLabelButton(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiLabelButton(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Toggle Button control
 pub fn guiToggle(bounds: Rectangle, text: [:0]const u8, active: *bool) i32 {
     return @as(i32, cdef.GuiToggle(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]bool, @ptrCast(active))));
 }
 
-/// Toggle Group control
 pub fn guiToggleGroup(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiToggleGroup(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
-/// Toggle Slider control
 pub fn guiToggleSlider(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiToggleSlider(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
-/// Check Box control, returns true when active
 pub fn guiCheckBox(bounds: Rectangle, text: [:0]const u8, checked: *bool) i32 {
     return @as(i32, cdef.GuiCheckBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]bool, @ptrCast(checked))));
 }
 
-/// Combo Box control
 pub fn guiComboBox(bounds: Rectangle, text: [:0]const u8, active: *i32) i32 {
     return @as(i32, cdef.GuiComboBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active))));
 }
 
-/// Dropdown Box control
 pub fn guiDropdownBox(bounds: Rectangle, text: [:0]const u8, active: *i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiDropdownBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(active)), editMode));
 }
 
-/// Spinner control
 pub fn guiSpinner(bounds: Rectangle, text: [:0]const u8, value: *i32, minValue: i32, maxValue: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiSpinner(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(value)), @as(c_int, minValue), @as(c_int, maxValue), editMode));
 }
 
-/// Value Box control, updates input text with numbers
 pub fn guiValueBox(bounds: Rectangle, text: [:0]const u8, value: *i32, minValue: i32, maxValue: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiValueBox(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(value)), @as(c_int, minValue), @as(c_int, maxValue), editMode));
 }
 
-/// Value box control for float values
 pub fn guiValueBoxFloat(bounds: Rectangle, text: [:0]const u8, textValue: [:0]u8, value: *f32, editMode: bool) i32 {
     return @as(i32, cdef.GuiValueBoxFloat(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]u8, @ptrCast(textValue)), @as([*c]f32, @ptrCast(value)), editMode));
 }
 
-/// Text Box control, updates input text
 pub fn guiTextBox(bounds: Rectangle, text: [:0]u8, textSize: i32, editMode: bool) i32 {
     return @as(i32, cdef.GuiTextBox(bounds, @as([*c]u8, @ptrCast(text)), @as(c_int, textSize), editMode));
 }
 
-/// Slider control
 pub fn guiSlider(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiSlider(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
-/// Slider Bar control
 pub fn guiSliderBar(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiSliderBar(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
-/// Progress Bar control
 pub fn guiProgressBar(bounds: Rectangle, textLeft: [:0]const u8, textRight: [:0]const u8, value: *f32, minValue: f32, maxValue: f32) i32 {
     return @as(i32, cdef.GuiProgressBar(bounds, @as([*c]const u8, @ptrCast(textLeft)), @as([*c]const u8, @ptrCast(textRight)), @as([*c]f32, @ptrCast(value)), minValue, maxValue));
 }
 
-/// Status Bar control, shows info text
 pub fn guiStatusBar(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiStatusBar(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Dummy control for placeholders
 pub fn guiDummyRec(bounds: Rectangle, text: [:0]const u8) i32 {
     return @as(i32, cdef.GuiDummyRec(bounds, @as([*c]const u8, @ptrCast(text))));
 }
 
-/// Grid control
 pub fn guiGrid(bounds: Rectangle, text: [:0]const u8, spacing: f32, subdivs: i32, mouseCell: *Vector2) i32 {
     return @as(i32, cdef.GuiGrid(bounds, @as([*c]const u8, @ptrCast(text)), spacing, @as(c_int, subdivs), @as([*c]Vector2, @ptrCast(mouseCell))));
 }
 
-/// List View control
 pub fn guiListView(bounds: Rectangle, text: [:0]const u8, scrollIndex: *i32, active: *i32) i32 {
     return @as(i32, cdef.GuiListView(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(scrollIndex)), @as([*c]c_int, @ptrCast(active))));
 }
 
-/// Message Box control, displays a message
 pub fn guiMessageBox(bounds: Rectangle, title: [:0]const u8, message: [:0]const u8, buttons: [:0]const u8) i32 {
     return @as(i32, cdef.GuiMessageBox(bounds, @as([*c]const u8, @ptrCast(title)), @as([*c]const u8, @ptrCast(message)), @as([*c]const u8, @ptrCast(buttons))));
 }
 
-/// Text Input Box control, ask for text, supports secret
 pub fn guiTextInputBox(bounds: Rectangle, title: [:0]const u8, message: [:0]const u8, buttons: [:0]const u8, text: [:0]u8, textMaxSize: i32, secretViewActive: *bool) i32 {
     return @as(i32, cdef.GuiTextInputBox(bounds, @as([*c]const u8, @ptrCast(title)), @as([*c]const u8, @ptrCast(message)), @as([*c]const u8, @ptrCast(buttons)), @as([*c]u8, @ptrCast(text)), @as(c_int, textMaxSize), @as([*c]bool, @ptrCast(secretViewActive))));
 }
 
-/// Color Picker control (multiple color controls)
 pub fn guiColorPicker(bounds: Rectangle, text: [:0]const u8, color: *Color) i32 {
     return @as(i32, cdef.GuiColorPicker(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Color, @ptrCast(color))));
 }
 
-/// Color Panel control
 pub fn guiColorPanel(bounds: Rectangle, text: [:0]const u8, color: *Color) i32 {
     return @as(i32, cdef.GuiColorPanel(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Color, @ptrCast(color))));
 }
 
-/// Color Bar Alpha control
 pub fn guiColorBarAlpha(bounds: Rectangle, text: [:0]const u8, alpha: *f32) i32 {
     return @as(i32, cdef.GuiColorBarAlpha(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]f32, @ptrCast(alpha))));
 }
 
-/// Color Bar Hue control
 pub fn guiColorBarHue(bounds: Rectangle, text: [:0]const u8, value: *f32) i32 {
     return @as(i32, cdef.GuiColorBarHue(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]f32, @ptrCast(value))));
 }
 
-/// Color Picker control that avoids conversion to RGB on each call (multiple color controls)
 pub fn guiColorPickerHSV(bounds: Rectangle, text: [:0]const u8, colorHsv: *Vector3) i32 {
     return @as(i32, cdef.GuiColorPickerHSV(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Vector3, @ptrCast(colorHsv))));
 }
 
-/// Color Panel control that updates Hue-Saturation-Value color value, used by GuiColorPickerHSV()
 pub fn guiColorPanelHSV(bounds: Rectangle, text: [:0]const u8, colorHsv: *Vector3) i32 {
     return @as(i32, cdef.GuiColorPanelHSV(bounds, @as([*c]const u8, @ptrCast(text)), @as([*c]Vector3, @ptrCast(colorHsv))));
 }

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -20,122 +20,156 @@ pub const Vector2 = extern struct {
         return Vector2{ .x = x, .y = y };
     }
 
+    /// Vector with components value 0.0
     pub fn zero() Vector2 {
         return math.vector2Zero();
     }
 
+    /// Vector with components value 1.0
     pub fn one() Vector2 {
         return math.vector2One();
     }
 
+    /// Add two vectors (v1 + v2)
     pub fn add(self: Vector2, v: Vector2) Vector2 {
         return math.vector2Add(self, v);
     }
 
+    /// Add vector and float value
     pub fn addValue(self: Vector2, v: f32) Vector2 {
         return math.vector2AddValue(self, v);
     }
 
+    /// Subtract two vectors (v1 - v2)
     pub fn subtract(self: Vector2, v: Vector2) Vector2 {
         return math.vector2Subtract(self, v);
     }
 
+    /// Subtract vector by float value
     pub fn subtractValue(self: Vector2, v: f32) Vector2 {
         return math.vector2SubtractValue(self, v);
     }
 
+    /// Calculate vector length
     pub fn length(self: Vector2) f32 {
         return math.vector2Length(self);
     }
 
+    /// Calculate vector square length
     pub fn lengthSqr(self: Vector2) f32 {
         return math.vector2LengthSqr(self);
     }
 
+    /// Calculate two vectors dot product
     pub fn dotProduct(self: Vector2, v: Vector2) f32 {
         return math.vector2DotProduct(self, v);
     }
 
+    /// Calculate distance between two vectors
     pub fn distance(self: Vector2, v: Vector2) f32 {
         return math.vector2Distance(self, v);
     }
 
+    /// Calculate square distance between two vectors
     pub fn distanceSqr(self: Vector2, v: Vector2) f32 {
         return math.vector2DistanceSqr(self, v);
     }
 
+    /// Calculate angle from two vectors
     pub fn angle(self: Vector2, v: Vector2) f32 {
         return math.vector2Angle(self, v);
     }
 
+    /// Calculate angle defined by a two vectors line
     pub fn lineAngle(self: Vector2, end: Vector2) f32 {
         return math.vector2LineAngle(self, end);
     }
 
+    /// Scale vector (multiply by value)
     pub fn scale(self: Vector2, scale_: f32) Vector2 {
         return math.vector2Scale(self, scale_);
     }
 
+    /// Multiply vector by vector
     pub fn multiply(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Multiply(self, v2);
     }
 
+    /// Negate vector
     pub fn negate(self: Vector2) Vector2 {
         return math.vector2Negate(self);
     }
 
+    /// Divide vector by vector
     pub fn divide(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Divide(self, v2);
     }
 
+    /// Normalize provided vector
     pub fn normalize(self: Vector2) Vector2 {
         return math.vector2Normalize(self);
     }
 
+    /// Transforms a Vector2 by a given Matrix
     pub fn transform(self: Vector2, mat: Matrix) Vector2 {
         return math.vector2Transform(self, mat);
     }
 
+    /// Calculate linear interpolation between two vectors
     pub fn lerp(self: Vector2, v2: Vector2, amount: f32) Vector2 {
         return math.vector2Lerp(self, v2, amount);
     }
 
+    /// Calculate reflected vector to normal
     pub fn reflect(self: Vector2, normal: Vector2) Vector2 {
         return math.vector2Reflect(self, normal);
     }
 
+    /// Get min value for each pair of components
     pub fn min(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Min(self, v2);
     }
 
+    /// Get max value for each pair of components
     pub fn max(self: Vector2, v2: Vector2) Vector2 {
         return math.vector2Max(self, v2);
     }
 
+    /// Rotate vector by angle
     pub fn rotate(self: Vector2, angle_: f32) Vector2 {
         return math.vector2Rotate(self, angle_);
     }
 
+    /// Move Vector towards target
     pub fn moveTowards(self: Vector2, target: Vector2, maxDistance: f32) Vector2 {
         return math.vector2MoveTowards(self, target, maxDistance);
     }
 
+    /// Invert the given vector
     pub fn invert(self: Vector2) Vector2 {
         return math.vector2Invert(self);
     }
 
+    /// Clamp the components of the vector between min and max values specified by the given vectors
     pub fn clamp(self: Vector2, min_: Vector2, max_: Vector2) Vector2 {
         return math.vector2Clamp(self, min_, max_);
     }
 
+    /// Clamp the magnitude of the vector between two min and max values
     pub fn clampValue(self: Vector2, min_: f32, max_: f32) Vector2 {
         return math.vector2ClampValue(self, min_, max_);
     }
 
+    /// Check whether two given vectors are almost equal
     pub fn equals(self: Vector2, q: Vector2) i32 {
         return math.vector2Equals(self, q);
     }
 
+    /// Compute the direction of a refracted ray
+    /// v: normalized direction of the incoming ray
+    /// n: normalized normal vector of the interface of two optical media
+    /// r: ratio of the refractive index of the medium from where the ray comes
+    ///    to the refractive index of the medium on the other side of the surface
     pub fn refract(self: Vector2, n: Vector2, r: f32) Vector2 {
         return math.vector2Refract(self, n, r);
     }
@@ -150,158 +184,205 @@ pub const Vector3 = extern struct {
         return Vector3{ .x = x, .y = y, .z = z };
     }
 
+    // Vector with components value 0.0
     pub fn zero() Vector3 {
         return math.vector3Zero();
     }
 
+    /// Vector with components value 1.0
     pub fn one() Vector3 {
         return math.vector3One();
     }
 
+    /// Add two vectors
     pub fn add(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Add(self, v);
     }
 
+    /// Add vector and float value
     pub fn addValue(self: Vector3, add_: f32) Vector3 {
         return math.vector3AddValue(self, add_);
     }
 
+    /// Subtract two vectors
     pub fn subtract(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Subtract(self, v);
     }
 
+    /// Subtract vector by float value
     pub fn subtractValue(self: Vector3, sub: f32) Vector3 {
         return math.vector3SubtractValue(self, sub);
     }
 
+    /// Multiply vector by scalar
     pub fn scale(self: Vector3, scalar: f32) Vector3 {
         return math.vector3Scale(self, scalar);
     }
 
+    /// Multiply vector by vector
     pub fn multiply(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Multiply(self, v);
     }
 
+    /// Calculate two vectors cross product
     pub fn crossProduct(self: Vector3, v: Vector3) Vector3 {
         return math.vector3CrossProduct(self, v);
     }
 
+    /// Calculate one vector perpendicular vector
     pub fn perpendicular(self: Vector3) Vector3 {
         return math.vector3Perpendicular(self);
     }
 
+    /// Calculate vector length
     pub fn length(self: Vector3) f32 {
         return math.vector3Length(self);
     }
 
+    /// Calculate vector square length
     pub fn lengthSqr(self: Vector3) f32 {
         return math.vector3LengthSqr(self);
     }
 
+    /// Calculate two vectors dot product
     pub fn dotProduct(self: Vector3, v: Vector3) f32 {
         return math.vector3DotProduct(self, v);
     }
 
+    /// Calculate distance between two vectors
     pub fn distance(self: Vector3, v: Vector3) f32 {
         return math.vector3Distance(self, v);
     }
 
+    /// Calculate square distance between two vectors
     pub fn distanceSqr(self: Vector3, v: Vector3) f32 {
         return math.vector3DistanceSqr(self, v);
     }
 
+    /// Calculate angle between two vectors
     pub fn angle(self: Vector3, v: Vector3) f32 {
         return math.vector3Angle(self, v);
     }
 
+    /// Negate vector (invert direction)
     pub fn negate(self: Vector3) Vector3 {
         return math.vector3Negate(self);
     }
 
+    /// Divide vector by vector
     pub fn divide(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Divide(self, v);
     }
 
+    /// Normalize provided vector
     pub fn normalize(self: Vector3) Vector3 {
         return math.vector3Normalize(self);
     }
 
+    /// Calculate the projection of the vector v1 on to v2
     pub fn project(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Project(self, v);
     }
 
+    /// Calculate the rejection of the vector v1 on to v2
     pub fn reject(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Reject(self, v);
     }
 
+    /// Orthonormalize provided vectors Makes vectors normalized and orthogonal
+    /// to each other Gram-Schmidt function implementation
     pub fn orthoNormalize(self: *Vector3, v: *Vector3) void {
         math.vector3OrthoNormalize(self, v);
     }
 
+    /// Transforms a Vector3 by a given Matrix
     pub fn transform(self: Vector3, mat: Matrix) Vector3 {
         return math.vector3Transform(self, mat);
     }
 
+    /// Transform a vector by quaternion rotation
     pub fn rotateByQuaternion(self: Vector3, q: Quaternion) Vector3 {
         return math.vector3RotateByQuaternion(self, q);
     }
 
+    /// Rotates a vector around an axis
     pub fn rotateByAxisAngle(self: Vector3, axis: Vector3, angle_: f32) Vector3 {
         return math.vector3RotateByAxisAngle(self, axis, angle_);
     }
 
+    /// Move Vector towards target
     pub fn moveTowards(self: Vector3, target: Vector3, maxDistance: f32) Vector3 {
         return math.vector3MoveTowards(self, target, maxDistance);
     }
 
+    /// Calculate linear interpolation between two vectors
     pub fn lerp(self: Vector3, v2: Vector3, amount: f32) Vector3 {
         return math.vector3Lerp(self, v2, amount);
     }
 
+    /// Calculate cubic hermite interpolation between two vectors and their tangents
+    /// as described in the GLTF 2.0 specification
     pub fn cubicHermite(self: Vector3, tangent1: Vector3, v: Vector3, tangent2: Vector3, amount: f32) Vector3 {
         return math.vector3CubicHermite(self, tangent1, v, tangent2, amount);
     }
 
+    /// Calculate reflected vector to normal
     pub fn reflect(self: Vector3, normal: Vector3) Vector3 {
         return math.vector3Reflect(self, normal);
     }
 
+    /// Get min value for each pair of components
     pub fn min(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Min(self, v);
     }
 
+    /// Get max value for each pair of components
     pub fn max(self: Vector3, v: Vector3) Vector3 {
         return math.vector3Max(self, v);
     }
 
+    /// Compute barycenter coordinates (u, v, w) for point p with respect to triangle
+    /// (a, b, c) NOTE: Assumes P is on the plane of the triangle
     pub fn barycenter(p: Vector3, a: Vector3, b: Vector3, c: Vector3) Vector3 {
         return math.vector3Barycenter(p, a, b, c);
     }
 
+    /// Projects a Vector3 from screen space into object space
+    /// NOTE: We are avoiding calling other raymath functions despite available
     pub fn unproject(source: Vector3, projection: Matrix, view: Matrix) Vector3 {
         return math.vector3Unproject(source, projection, view);
     }
 
+    /// Get Vector3 as float array
     pub fn toFloatV(self: Vector3) math.float3 {
         return math.vector3ToFloatV(self);
     }
 
+    /// Invert the given vector
     pub fn invert(self: Vector3) Vector3 {
         return math.vector3Invert(self);
     }
 
+    /// Clamp the components of the vector between min and max values specified by the given vectors
     pub fn clamp(self: Vector3, min_: Vector3, max_: Vector3) Vector3 {
         return math.vector3Clamp(self, min_, max_);
     }
 
+    /// Clamp the magnitude of the vector between two values
     pub fn clampValue(self: Vector3, min_: f32, max_: f32) Vector3 {
         return math.vector3ClampValue(self, min_, max_);
     }
 
+    /// Check whether two given vectors are almost equal
     pub fn equals(p: Vector3, q: Vector3) i32 {
         return math.vector3Equals(p, q);
     }
 
+    /// Compute the direction of a refracted ray
+    /// v: normalized direction of the incoming ray
+    /// n: normalized normal vector of the interface of two optical media
+    /// r: ratio of the refractive index of the medium from where the ray comes
+    ///    to the refractive index of the medium on the other side of the surface
     pub fn refract(self: Vector3, n: Vector3, r: f32) Vector3 {
         return math.vector3Refract(self, n, r);
     }
@@ -317,138 +398,176 @@ pub const Vector4 = extern struct {
         return Vector4{ .x = x, .y = y, .z = z, .w = w };
     }
 
+    /// Vector with components value 0.0
     pub fn zero() Vector4 {
         return math.vector4Zero();
     }
 
+    /// Vector with components value 1.0
     pub fn one() Vector4 {
         return math.vector4One();
     }
 
+    /// Add two vectors
     pub fn add(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Add(self, v);
     }
 
+    /// Add vector and float value
     pub fn addValue(self: Vector4, add_: f32) Vector4 {
         return math.vector4AddValue(self, add_);
     }
 
+    /// Subtract two vectors
     pub fn subtract(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Subtract(self, v);
     }
 
+    /// Subtract vector and float value
     pub fn subtractValue(self: Vector4, add_: f32) Vector4 {
         return math.vector4SubtractValue(self, add_);
     }
 
+    /// Computes the length of a vector
     pub fn length(self: Vector4) f32 {
         return math.vector4Length(self);
     }
 
+    /// Calculate vector square length
     pub fn lengthSqr(self: Vector4) f32 {
         return math.vector4LengthSqr(self);
     }
 
+    /// Calculate two vectors dot product
     pub fn dotProduct(self: Vector4, v: Vector4) f32 {
         return math.vector4DotProduct(self, v);
     }
 
+    /// Calculate distance between two vectors
     pub fn distance(self: Vector4, v: Vector4) f32 {
         return math.vector4Distance(self, v);
     }
 
+    /// Calculate square distance between two vectors
     pub fn distanceSqr(self: Vector4, v: Vector4) f32 {
         return math.vector4DistanceSqr(self, v);
     }
 
+    /// Scale vector by float value
     pub fn scale(self: Vector4, scale_: f32) Vector4 {
         return math.vector4Scale(self, scale_);
     }
 
+    /// Multiply vector by vector
     pub fn multiply(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Multiply(self, v);
     }
 
+    /// Negate vector
     pub fn negate(self: Vector4) Vector4 {
         return math.vector4Negate(self);
     }
 
+    /// Divide two vectors
     pub fn divide(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Divide(self, v);
     }
 
+    /// Normalize vector
     pub fn normalize(self: Vector4) Vector4 {
         return math.vector4Normalize(self);
     }
 
+    /// Get min value for each pair of components
     pub fn min(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Min(self, v);
     }
 
+    /// Get max value for each pair of components
     pub fn max(self: Vector4, v: Vector4) Vector4 {
         return math.vector4Max(self, v);
     }
 
+    /// Calculate linear interpolation between two vectors
     pub fn lerp(self: Vector4, v: Vector4, amount: f32) Vector4 {
         return math.vector4Lerp(self, v, amount);
     }
 
+    /// Move Vector towards target
     pub fn moveTowards(self: Vector4, target: Vector4, maxDistance: f32) Vector4 {
         return math.vector4MoveTowards(self, target, maxDistance);
     }
 
+    /// Invert provided quaternion
     pub fn invert(self: Vector4) Vector4 {
         return math.vector4Invert(self);
     }
 
+    /// Check whether two given quaternions are almost equal
     pub fn equals(p: Vector4, q: Vector4) i32 {
         return math.vector4Equals(p, q);
     }
 
+    /// Get identity quaternion
     pub fn identity() Quaternion {
         return math.quaternionIdentity();
     }
 
+    /// Calculate slerp-optimized interpolation between two quaternions
     pub fn nlerp(self: Quaternion, q: Quaternion, amount: f32) Quaternion {
         return math.quaternionNlerp(self, q, amount);
     }
 
+    /// Calculates spherical linear interpolation between two quaternions
     pub fn slerp(self: Quaternion, q: Quaternion, amount: f32) Quaternion {
         return math.quaternionSlerp(self, q, amount);
     }
 
+    /// Calculate quaternion cubic spline interpolation using Cubic Hermite Spline
+    /// algorithm as described in the GLTF 2.0 specification
     pub fn cubicHermiteSpline(self: Quaternion, outTangent1: Quaternion, q: Quaternion, inTangent2: Quaternion, t: f32) Quaternion {
         return math.quaternionCubicHermiteSpline(self, outTangent1, q, inTangent2, t);
     }
 
+    // Calculate quaternion based on the rotation from one vector to another
     pub fn fromVector3ToVector3(from: Vector3, to: Vector3) Quaternion {
         return math.quaternionFromVector3ToVector3(from, to);
     }
 
+    /// Get a quaternion for a given rotation matrix
     pub fn fromMatrix(mat: Matrix) Quaternion {
         return math.quaternionFromMatrix(mat);
     }
 
+    /// Get a matrix for a given quaternion
     pub fn toMatrix(self: Quaternion) Matrix {
         return math.quaternionToMatrix(self);
     }
 
+    /// Get rotation quaternion for an angle and axis
+    /// NOTE: Angle must be provided in radians
     pub fn fromAxisAngle(axis: Vector3, angle: f32) Quaternion {
         return math.quaternionFromAxisAngle(axis, angle);
     }
 
+    /// Get the rotation angle and axis for a given quaternion
     pub fn toAxisAngle(self: Quaternion, outAxis: *Vector3, outAngle: *f32) void {
         math.quaternionToAxisAngle(self, outAxis, outAngle);
     }
 
+    /// Get the quaternion equivalent to Euler angles
+    /// NOTE: Rotation order is ZYX
     pub fn fromEuler(pitch: f32, yaw: f32, roll: f32) Quaternion {
         return math.quaternionFromEuler(pitch, yaw, roll);
     }
 
+    /// Get the Euler angles equivalent to quaternion (roll, pitch, yaw)
+    /// NOTE: Angles are returned in a Vector3 struct in radians
     pub fn toEuler(self: Quaternion) Vector3 {
         return math.quaternionToEuler(self);
     }
 
+    /// Transform a quaternion given a transformation matrix
     pub fn transform(self: Quaternion, mat: Matrix) Quaternion {
         return math.quaternionTransform(self, mat);
     }
@@ -473,86 +592,115 @@ pub const Matrix = extern struct {
     m11: f32,
     m15: f32,
 
+    /// Compute matrix determinant
     pub fn determinant(self: Matrix) f32 {
         return math.matrixDeterminant(self);
     }
 
+    /// Get the trace of the matrix (sum of the values along the diagonal)
     pub fn trace(self: Matrix) f32 {
         return math.matrixTrace(self);
     }
 
+    /// Transposes provided matrix
     pub fn transpose(self: Matrix) Matrix {
         return math.matrixTranspose(self);
     }
 
+    /// Invert provided matrix
     pub fn invert(self: Matrix) Matrix {
         return math.matrixInvert(self);
     }
 
+    /// Get identity matrix
     pub fn identity() Matrix {
         return math.matrixIdentity();
     }
 
+    /// Add two matrices
     pub fn add(self: Matrix, right: Matrix) Matrix {
         return math.matrixAdd(self, right);
     }
 
+    /// Subtract two matrices (left - right)
     pub fn subtract(self: Matrix, right: Matrix) Matrix {
         return math.matrixSubtract(self, right);
     }
 
+    /// Get two matrix multiplication
+    /// NOTE: When multiplying matrices... the order matters!
     pub fn multiply(self: Matrix, right: Matrix) Matrix {
         return math.matrixMultiply(self, right);
     }
 
+    /// Get translation matrix
     pub fn translate(x: f32, y: f32, z: f32) Matrix {
         return math.matrixTranslate(x, y, z);
     }
 
+    /// Create rotation matrix from axis and angle
+    /// NOTE: Angle should be provided in radians
     pub fn rotate(axis: Vector3, angle: f32) Matrix {
         return math.matrixRotate(axis, angle);
     }
 
+    /// Get x-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateX(angle: f32) Matrix {
         return math.matrixRotateX(angle);
     }
 
+    /// Get y-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateY(angle: f32) Matrix {
         return math.matrixRotateY(angle);
     }
 
+    /// Get z-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateZ(angle: f32) Matrix {
         return math.matrixRotateZ(angle);
     }
 
+    /// Get xyz-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateXYZ(angle: Vector3) Matrix {
         return math.matrixRotateXYZ(angle);
     }
 
+    /// Get zyx-rotation matrix
+    /// NOTE: Angle must be provided in radians
     pub fn rotateZYX(angle: Vector3) Matrix {
         return math.matrixRotateZYX(angle);
     }
 
+    /// Get scaling matrix
     pub fn scale(x: f32, y: f32, z: f32) Matrix {
         return math.matrixScale(x, y, z);
     }
 
+    /// Get perspective projection matrix
     pub fn frustum(left: f64, right: f64, bottom: f64, top: f64, near: f64, far: f64) Matrix {
         return math.matrixFrustum(left, right, bottom, top, near, far);
     }
 
+    /// Get perspective projection matrix
+    /// NOTE: Fovy angle must be provided in radians
     pub fn perspective(fovY: f64, aspect: f64, nearPlane: f64, farPlane: f64) Matrix {
         return math.matrixPerspective(fovY, aspect, nearPlane, farPlane);
     }
 
+    /// Get orthographic projection matrix
     pub fn ortho(left: f64, right: f64, bottom: f64, top: f64, nearPlane: f64, farPlane: f64) Matrix {
         return math.matrixOrtho(left, right, bottom, top, nearPlane, farPlane);
     }
 
+    /// Get camera look-at matrix (view matrix)
     pub fn lookAt(eye: Vector3, target: Vector3, up: Vector3) Matrix {
         return math.matrixLookAt(eye, target, up);
     }
 
+    /// Get float array of matrix data
     pub fn toFloatV(self: Matrix) math.float16 {
         return math.matrixToFloatV(self);
     }
@@ -596,46 +744,57 @@ pub const Color = extern struct {
         return Color{ .r = r, .g = g, .b = b, .a = a };
     }
 
+    /// Get Color from normalized values [0..1]
     pub fn fromNormalized(normalized: Vector4) Color {
         return rl.colorFromNormalized(normalized);
     }
 
+    /// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
     pub fn fromHSV(hue: f32, saturation: f32, value: f32) Color {
         return rl.colorFromHSV(hue, saturation, value);
     }
 
+    /// Get a Color from hexadecimal value
     pub fn fromInt(hexValue: u32) Color {
         return rl.getColor(hexValue);
     }
 
+    /// Get color with alpha applied, alpha goes from 0.0 to 1.0
     pub fn fade(self: Color, a: f32) Color {
         return rl.fade(self, a);
     }
 
+    /// Get color multiplied with another color
     pub fn tint(self: Color, t: Color) Color {
         return rl.colorTint(self, t);
     }
 
+    /// Get Color normalized as float [0..1]
     pub fn normalize(self: Color) Vector4 {
         return rl.colorNormalize(self);
     }
 
+    /// Get color with brightness correction, brightness factor goes from -1.0 to 1.0
     pub fn brightness(self: Color, factor: f32) Color {
         return rl.colorBrightness(self, factor);
     }
 
+    /// Get color with contrast correction, contrast values between -1.0 and 1.0
     pub fn contrast(self: Color, c: f32) Color {
         return rl.colorContrast(self, c);
     }
 
+    /// Get color with alpha applied, alpha goes from 0.0 to 1.0
     pub fn alpha(self: Color, a: f32) Color {
         return rl.colorAlpha(self, a);
     }
 
+    /// Get hexadecimal value for a Color
     pub fn toInt(self: Color) i32 {
         return rl.colorToInt(self);
     }
 
+    /// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
     pub fn toHSV(self: Color) Vector3 {
         return rl.colorToHSV(self);
     }
@@ -651,10 +810,12 @@ pub const Rectangle = extern struct {
         return Rectangle{ .x = x, .y = y, .width = width, .height = height };
     }
 
+    /// Check collision between two rectangles
     pub fn checkCollision(self: Rectangle, rec2: Rectangle) bool {
         return rl.checkCollisionRecs(self, rec2);
     }
 
+    /// Get collision rectangle for two rectangles collision
     pub fn getCollision(self: Rectangle, rec2: Rectangle) Rectangle {
         return rl.getCollisionRec(self, rec2);
     }
@@ -667,262 +828,327 @@ pub const Image = extern struct {
     mipmaps: c_int,
     format: PixelFormat,
 
+    /// Load image from file into CPU memory (RAM)
     pub fn init(fileName: [:0]const u8) Image {
         return rl.loadImage(fileName);
     }
 
+    /// Load image from RAW file data
     pub fn initRaw(fileName: [:0]const u8, width: i32, height: i32, format: PixelFormat, headerSize: i32) Image {
         return rl.loadImageRaw(fileName, width, height, format, headerSize);
     }
 
+    /// Load image sequence from file (frames appended to image.data)
     pub fn initAnim(fileName: [:0]const u8, frames: *i32) Image {
         return rl.loadImageAnim(fileName, frames);
     }
 
+    /// Load image from GPU texture data
     pub fn fromTexture(texture: Texture) Image {
         return rl.loadImageFromTexture(texture);
     }
 
+    /// Load image from screen buffer and (screenshot)
     pub fn fromScreen() Image {
         return rl.loadImageFromScreen();
     }
 
+    /// Unload image from CPU memory (RAM)
     pub fn unload(self: Image) void {
         rl.unloadImage(self);
     }
 
+    /// Create an image from text (default font)
     pub fn initText(text: [:0]const u8, fontSize: i32, color: Color) Image {
         return rl.imageText(text, fontSize, color);
     }
 
+    /// Create an image from text (custom sprite font)
     pub fn initTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32, t: Color) Image {
         return rl.imageTextEx(font, text, fontSize, spacing, t);
     }
 
+    /// Generate image: plain color
     pub fn genColor(width: i32, height: i32, color: Color) Image {
         return rl.genImageColor(width, height, color);
     }
 
+    /// Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
     pub fn genGradientLinear(width: i32, height: i32, direction: i32, start: Color, end: Color) Image {
         return rl.genImageGradientLinear(width, height, direction, start, end);
     }
 
+    /// Generate image: radial gradient
     pub fn genGradientRadial(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
         return rl.genImageGradientRadial(width, height, density, inner, outer);
     }
 
+    /// Generate image: square gradient
     pub fn genGradientSquare(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
         return rl.genImageGradientSquare(width, height, density, inner, outer);
     }
 
+    /// Generate image: checked
     pub fn genChecked(width: i32, height: i32, checksX: i32, checksY: i32, col1: Color, col2: Color) Image {
         return rl.genImageChecked(width, height, checksX, checksY, col1, col2);
     }
 
+    /// Generate image: white noise
     pub fn genWhiteNoise(width: i32, height: i32, factor: f32) Image {
         return rl.genImageWhiteNoise(width, height, factor);
     }
 
+    /// Generate image: perlin noise
     pub fn genPerlinNoise(width: i32, height: i32, offsetX: i32, offsetY: i32, scale: f32) Image {
         return rl.genImagePerlinNoise(width, height, offsetX, offsetY, scale);
     }
 
+    /// Generate image: cellular algorithm, bigger tileSize means bigger cells
     pub fn genCellular(width: i32, height: i32, tileSize: i32) Image {
         return rl.genImageCellular(width, height, tileSize);
     }
 
+    /// Generate image: grayscale image from text data
     pub fn genText(width: i32, height: i32, text: [:0]const u8) Image {
         return rl.genImageText(width, height, text);
     }
 
+    /// Create an image duplicate (useful for transformations)
     pub fn copy(self: Image) Image {
         return rl.imageCopy(self);
     }
 
+    /// Create an image from another image piece
     pub fn copyRec(self: Image, rec: Rectangle) Image {
         return rl.imageFromImage(self, rec);
     }
 
+    /// Convert image data to desired format
     pub fn setFormat(self: *Image, newFormat: PixelFormat) void {
         return rl.imageFormat(self, newFormat);
     }
 
+    /// Convert image to POT (power-of-two)
     pub fn toPOT(self: *Image, fill: Color) void {
         rl.imageToPOT(self, fill);
     }
 
+    /// Crop an image to a defined rectangle
     pub fn crop(self: *Image, c: Rectangle) void {
         rl.imageCrop(self, c);
     }
 
+    /// Crop image depending on alpha value
     pub fn alphaCrop(self: *Image, threshold: f32) void {
         rl.imageAlphaCrop(self, threshold);
     }
 
+    /// Clear alpha channel to desired color
     pub fn alphaClear(self: *Image, color: Color, threshold: f32) void {
         rl.imageAlphaClear(self, color, threshold);
     }
 
+    /// Apply alpha mask to image
     pub fn alphaMask(self: *Image, am: Image) void {
         rl.imageAlphaMask(self, am);
     }
 
+    /// Premultiply alpha channel
     pub fn alphaPremultiply(self: *Image) void {
         rl.imageAlphaPremultiply(self);
     }
 
+    /// Apply Gaussian blur using a box blur approximation
     pub fn blurGaussian(self: *Image, blurSize: i32) void {
         rl.imageBlurGaussian(self, blurSize);
     }
 
+    /// Resize image (Bicubic scaling algorithm)
     pub fn resize(self: *Image, newWidth: i32, newHeight: i32) void {
         rl.imageResize(self, newWidth, newHeight);
     }
 
+    /// Resize image (Nearest-Neighbor scaling algorithm)
     pub fn resizeNN(self: *Image, newWidth: i32, newHeight: i32) void {
         rl.imageResizeNN(self, newWidth, newHeight);
     }
 
+    /// Resize canvas and fill with color
     pub fn resizeCanvas(self: *Image, newWidth: i32, newHeight: i32, offsetX: i32, offsetY: i32, fill: Color) void {
         rl.imageResizeCanvas(self, newWidth, newHeight, offsetX, offsetY, fill);
     }
 
+    /// Compute all mipmap levels for a provided image
     pub fn mimaps(self: *Image) void {
         rl.imageMipmaps(self);
     }
 
+    /// Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
     pub fn dither(self: *Image, rBpp: i32, gBpp: i32, bBpp: i32, aBpp: i32) void {
         rl.imageDither(self, rBpp, gBpp, bBpp, aBpp);
     }
 
+    /// Flip image vertically
     pub fn flipVertical(self: *Image) void {
         rl.imageFlipVertical(self);
     }
 
+    /// Flip image horizontally
     pub fn flipHorizontal(self: *Image) void {
         rl.imageFlipHorizontal(self);
     }
 
+    /// Rotate image by input angle in degrees (-359 to 359)
     pub fn rotate(self: *Image, degrees: i32) void {
         rl.imageRotate(self, degrees);
     }
 
+    /// Rotate image clockwise 90deg
     pub fn rotateCW(self: *Image) void {
         rl.imageRotateCW(self);
     }
 
+    /// Rotate image counter-clockwise 90deg
     pub fn rotateCCW(self: *Image) void {
         rl.imageRotateCCW(self);
     }
 
+    /// Modify image color: tint
     pub fn tint(self: *Image, color: Color) void {
         rl.imageColorTint(self, color);
     }
 
+    /// Modify image color: invert
     pub fn invert(self: *Image) void {
         rl.imageColorInvert(self);
     }
 
+    /// Modify image color: grayscale
     pub fn grayscale(self: *Image) void {
         rl.imageColorGrayscale(self);
     }
 
+    /// Modify image color: contrast (-100 to 100)
     pub fn contrast(self: *Image, c: f32) void {
         rl.imageColorContrast(self, c);
     }
 
+    /// Modify image color: brightness (-255 to 255)
     pub fn brightness(self: *Image, b: i32) void {
         rl.imageColorBrightness(self, b);
     }
 
+    /// Modify image color: replace color
     pub fn replaceColor(self: *Image, color: Color, replace: Color) void {
         rl.imageColorReplace(self, color, replace);
     }
 
+    /// Get image alpha border rectangle
     pub fn getAlphaBorder(self: Image, threshold: f32) Rectangle {
         return rl.getImageAlphaBorder(self, threshold);
     }
 
+    /// Get image pixel color at (x, y) position
     pub fn getColor(self: Image, x: i32, y: i32) Color {
         return rl.getImageColor(self, x, y);
     }
 
+    /// Clear image background with given color
     pub fn clearBackground(self: *Image, color: Color) void {
         rl.imageClearBackground(self, color);
     }
 
+    /// Draw pixel within an image
     pub fn drawPixel(self: *Image, posX: i32, posY: i32, color: Color) void {
         rl.imageDrawPixel(self, posX, posY, color);
     }
 
+    /// Draw pixel within an image (Vector version)
     pub fn drawPixelV(self: *Image, position: Vector2, color: Color) void {
         rl.imageDrawPixelV(self, position, color);
     }
 
+    /// Draw line within an image
     pub fn drawLine(self: *Image, startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
         rl.imageDrawLine(self, startPosX, startPosY, endPosX, endPosY, color);
     }
 
+    /// Draw line within an image (Vector version)
     pub fn drawLineV(self: *Image, start: Vector2, end: Vector2, color: Color) void {
         rl.imageDrawLineV(self, start, end, color);
     }
 
+    /// Draw a filled circle within an image
     pub fn drawCircle(self: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
         rl.imageDrawCircle(self, centerX, centerY, radius, color);
     }
 
+    /// Draw a filled circle within an image (Vector version)
     pub fn drawCircleV(self: *Image, center: Vector2, radius: i32, color: Color) void {
         rl.imageDrawCircleV(self, center, radius, color);
     }
 
+    /// Draw circle outline within an image
     pub fn drawCircleLines(self: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
         rl.imageDrawCircleLines(self, centerX, centerY, radius, color);
     }
 
+    /// Draw circle outline within an image (Vector version)
     pub fn drawCircleLinesV(self: *Image, center: Vector2, radius: i32, color: Color) void {
         rl.imageDrawCircleLinesV(self, center, radius, color);
     }
 
+    /// Draw rectangle within an image
     pub fn drawRectangle(self: *Image, posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
         rl.imageDrawRectangle(self, posX, posY, width, height, color);
     }
 
+    /// Draw rectangle within an image (Vector version)
     pub fn drawRectangleV(self: *Image, position: Vector2, size: Vector2, color: Color) void {
         rl.imageDrawRectangleV(self, position, size, color);
     }
 
+    /// Draw rectangle within an image
     pub fn drawRectangleRec(self: *Image, rec: Rectangle, color: Color) void {
         rl.imageDrawRectangleRec(self, rec, color);
     }
 
+    /// Draw rectangle lines within an image
     pub fn drawRectangleLines(self: *Image, rec: Rectangle, thick: i32, color: Color) void {
         rl.imageDrawRectangleLines(self, rec, thick, color);
     }
 
+    /// Draw a source image within a destination image (tint applied to source)
     pub fn drawImage(self: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, t: Color) void {
         rl.imageDraw(self, src, srcRec, dstRec, t);
     }
 
+    /// Draw text (using default font) within an image (destination)
     pub fn drawText(self: *Image, text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
         rl.imageDrawText(self, text, posX, posY, fontSize, color);
     }
 
+    /// Draw text (custom sprite font) within an image (destination)
     pub fn drawTextEx(self: *Image, font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, t: Color) void {
         rl.imageDrawTextEx(self, font, text, position, fontSize, spacing, t);
     }
 
+    /// Export image data to file, returns true on success
     pub fn exportToFile(self: Image, fileName: [:0]const u8) bool {
         return rl.exportImage(self, fileName);
     }
 
+    /// Export image as code file defining an array of bytes, returns true on success
     pub fn exportAsCode(self: Image, fileName: [:0]const u8) bool {
         return rl.exportImageAsCode(self, fileName);
     }
 
+    /// Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
     pub fn useAsWindowIcon(self: Image) void {
         rl.setWindowIcon(self);
     }
 
+    /// Load texture from image data
     pub fn toTexture(self: Image) Texture {
         return Texture.fromImage(self);
     }
@@ -943,38 +1169,47 @@ pub const Texture = extern struct {
         return rl.loadTexture(fileName);
     }
 
+    /// Load texture from image data
     pub fn fromImage(image: Image) Texture {
         return rl.loadTextureFromImage(image);
     }
 
+    /// Load cubemap from image, multiple image cubemap layouts supported
     pub fn fromCubemap(image: Image, layout: CubemapLayout) Texture {
         return rl.loadTextureCubemap(image, layout);
     }
 
+    /// Unload texture from GPU memory (VRAM)
     pub fn unload(self: Texture) void {
         rl.unloadTexture(self);
     }
 
+    /// Draw a Texture2D
     pub fn draw(self: Texture, posX: i32, posY: i32, tint: Color) void {
         rl.drawTexture(self, posX, posY, tint);
     }
 
+    /// Draw a Texture2D with position defined as Vector2
     pub fn drawV(self: Texture, position: Vector2, tint: Color) void {
         rl.drawTextureV(self, position, tint);
     }
 
+    /// Draw a Texture2D with extended parameters
     pub fn drawEx(self: Texture, position: Vector2, rotation: f32, scale: f32, tint: Color) void {
         rl.drawTextureEx(self, position, rotation, scale, tint);
     }
 
+    /// Draw a part of a texture defined by a rectangle
     pub fn drawRec(self: Texture, source: Rectangle, position: Vector2, tint: Color) void {
         rl.drawTextureRec(self, source, position, tint);
     }
 
+    /// Draw a part of a texture defined by a rectangle with 'pro' parameters
     pub fn drawPro(self: Texture, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
         rl.drawTexturePro(self, source, dest, origin, rotation, tint);
     }
 
+    /// Draws a texture (or part of it) that stretches or shrinks nicely
     pub fn drawNPatch(self: Texture, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
         rl.drawTextureNPatch(self, nPatchInfo, dest, origin, rotation, tint);
     }
@@ -991,14 +1226,17 @@ pub const RenderTexture = extern struct {
         return rl.loadRenderTexture(width, height);
     }
 
+    /// Unload render texture from GPU memory (VRAM)
     pub fn unload(self: RenderTexture) void {
         rl.unloadRenderTexture(self);
     }
 
+    /// Begin drawing to render texture
     pub fn begin(self: RenderTexture2D) void {
         rl.beginTextureMode(self);
     }
 
+    /// Ends drawing to render texture
     pub fn end(_: RenderTexture2D) void {
         rl.endTextureMode();
     }
@@ -1030,30 +1268,37 @@ pub const Font = extern struct {
     recs: [*c]Rectangle,
     glyphs: [*c]GlyphInfo,
 
+    /// Load font from file into GPU memory (VRAM)
     pub fn init(fileName: [:0]const u8) Font {
         return rl.loadFont(fileName);
     }
 
+    /// Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
     pub fn initEx(fileName: [:0]const u8, fontSize: i32, fontChars: []i32) Font {
         return rl.loadFontEx(fileName, fontSize, fontChars);
     }
 
+    /// Load font from Image (XNA style)
     pub fn fromImage(image: Image, key: Color, firstChar: i32) Font {
         return rl.loadFontFromImage(image, key, firstChar);
     }
 
+    /// Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
     pub fn fromMemory(fileType: [:0]const u8, fileData: ?[]const u8, fontSize: i32, fontChars: []i32) Font {
         return rl.loadFontFromMemory(fileType, fileData, fontSize, fontChars);
     }
 
+    /// Unload font from GPU memory (VRAM)
     pub fn unload(self: Font) void {
         rl.unloadFont(self);
     }
 
+    /// Check if a font is ready
     pub fn isReady(self: Font) bool {
         return rl.isFontReady(self);
     }
 
+    /// Export font as code file, returns true on success
     pub fn exportAsCode(self: Font, fileName: [:0]const u8) bool {
         return rl.exportFontAsCode(self, fileName);
     }
@@ -1066,18 +1311,22 @@ pub const Camera3D = extern struct {
     fovy: f32,
     projection: CameraProjection,
 
+    /// Begin 3D mode with camera
     pub fn begin(self: Camera3D) void {
         rl.beginMode3D(self);
     }
 
+    /// Update camera position for selected mode
     pub fn update(self: *Camera3D, mode: rl.CameraMode) void {
         rl.updateCamera(self, mode);
     }
 
+    /// Get camera transform matrix (view matrix)
     pub fn getMatrix(self: Camera3D) Matrix {
         return rl.getCameraMatrix(self);
     }
 
+    /// Ends 3D mode and returns to default 2D orthographic mode
     pub fn end(_: Camera3D) void {
         rl.endMode3D();
     }
@@ -1090,14 +1339,17 @@ pub const Camera2D = extern struct {
     rotation: f32,
     zoom: f32,
 
+    /// Begin 2D mode with camera
     pub fn begin(self: Camera2D) void {
         rl.beginMode2D(self);
     }
 
+    /// Get camera 2d transform matrix
     pub fn getMatrix(self: Camera2D) Matrix {
         return rl.getCameraMatrix2D(self);
     }
 
+    /// Ends 2D mode with camera
     pub fn end(_: Camera2D) void {
         rl.endMode2D();
     }
@@ -1120,10 +1372,12 @@ pub const Mesh = extern struct {
     vaoId: c_uint,
     vboId: [*c]c_uint,
 
+    /// Draw a 3d mesh with material and transform
     pub fn draw(self: Mesh, material: Material, transform: Matrix) void {
         rl.drawMesh(self, material, transform);
     }
 
+    /// Draw multiple mesh instances with material and different transforms
     pub fn drawInstanced(self: Mesh, material: Material, transforms: []const Matrix) void {
         rl.drawMeshInstanced(self, material, transforms);
     }
@@ -1133,10 +1387,12 @@ pub const Shader = extern struct {
     id: c_uint,
     locs: [*c]c_int,
 
+    /// Begin custom shader drawing
     pub fn activate(self: Shader) void {
         rl.beginShaderMode(self);
     }
 
+    /// End custom shader drawing (use default shader)
     pub fn deactivate(_: Shader) void {
         rl.endShaderMode();
     }
@@ -1176,30 +1432,37 @@ pub const Model = extern struct {
     bones: [*c]BoneInfo,
     bindPose: [*c]Transform,
 
+    /// Load model from file (meshes and materials)
     pub fn init(fileName: [:0]const u8) Model {
         return rl.loadModel(fileName);
     }
 
+    /// Load model from generated mesh (default material)
     pub fn fromMesh(mesh: Mesh) Model {
         return rl.loadModelFromMesh(mesh);
     }
 
+    /// Unload model (including meshes) from memory (RAM and/or VRAM)
     pub fn unload(self: Model) void {
         rl.unloadModel(self);
     }
 
+    /// Draw a model (with texture if set)
     pub fn draw(self: Model, position: Vector3, scale: f32, tint: Color) void {
         return rl.drawModel(self, position, scale, tint);
     }
 
+    /// Draw a model with extended parameters
     pub fn drawEx(self: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
         return rl.drawModelEx(self, position, rotationAxis, rotationAngle, scale, tint);
     }
 
+    /// Draw a model wires (with texture if set)
     pub fn drawWires(self: Model, position: Vector3, scale: f32, tint: Color) void {
         return rl.drawModelWires(self, position, scale, tint);
     }
 
+    /// Draw a model wires (with texture if set) with extended parameters
     pub fn drawWiresEx(self: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
         return rl.drawModelWiresEx(self, position, rotationAxis, rotationAngle, scale, tint);
     }
@@ -1298,11 +1561,7 @@ pub const AutomationEvent = extern struct {
     params: [4]c_int,
 };
 
-pub const AutomationEventList = extern struct {
-    capacity: c_uint,
-    count: c_uint,
-    events: [*c]AutomationEvent
-};
+pub const AutomationEventList = extern struct { capacity: c_uint, count: c_uint, events: [*c]AutomationEvent };
 
 pub const ConfigFlags = packed struct {
     __reserved: bool = false,
@@ -1704,10 +1963,12 @@ pub const SHADER_LOC_MAP_SPECULAR = ShaderLocationIndex.shader_loc_map_metalness
 
 const cdef = @import("raylib-ext.zig");
 
+/// Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
 pub fn setWindowIcons(images: []Image) void {
     cdef.SetWindowIcons(@as([*c]Image, @ptrCast(images)), @as(c_int, @intCast(images.len)));
 }
 
+/// Load shader from files and bind default locations
 pub fn loadShader(vsFileName: ?[:0]const u8, fsFileName: ?[:0]const u8) Shader {
     var vsFileNameFinal = @as([*c]const u8, 0);
     var fsFileNameFinal = @as([*c]const u8, 0);
@@ -1720,6 +1981,7 @@ pub fn loadShader(vsFileName: ?[:0]const u8, fsFileName: ?[:0]const u8) Shader {
     return cdef.LoadShader(vsFileNameFinal, fsFileNameFinal);
 }
 
+/// Load shader from code strings and bind default locations
 pub fn loadShaderFromMemory(vsCode: ?[:0]const u8, fsCode: ?[:0]const u8) Shader {
     var vsCodeFinal = @as([*c]const u8, 0);
     var fsCodeFinal = @as([*c]const u8, 0);
@@ -1732,6 +1994,7 @@ pub fn loadShaderFromMemory(vsCode: ?[:0]const u8, fsCode: ?[:0]const u8) Shader
     return cdef.LoadShaderFromMemory(vsCodeFinal, fsCodeFinal);
 }
 
+/// Load file data as byte array (read)
 pub fn loadFileData(fileName: [:0]const u8) RaylibError![]u8 {
     var bytesRead: i32 = 0;
     var res: []u8 = undefined;
@@ -1744,14 +2007,17 @@ pub fn loadFileData(fileName: [:0]const u8) RaylibError![]u8 {
     return res;
 }
 
+/// Save data to file from byte array (write), returns true on success
 pub fn saveFileData(fileName: [:0]const u8, data: []u8) bool {
     return cdef.SaveFileData(@as([*c]const u8, @ptrCast(fileName)), @as(*anyopaque, @ptrCast(data.ptr)), @as(c_int, @intCast(data.len)));
 }
 
+/// Export data to code (.h), returns true on success
 pub fn exportDataAsCode(data: []const u8, fileName: [:0]const u8) bool {
     return cdef.ExportDataAsCode(@as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)), @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Compress data (DEFLATE algorithm), memory must be MemFree()
 pub fn compressData(data: []const u8) []u8 {
     var compDataSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1760,6 +2026,7 @@ pub fn compressData(data: []const u8) []u8 {
     return res;
 }
 
+/// Decompress data (DEFLATE algorithm), memory must be MemFree()
 pub fn decompressData(compData: []const u8) []u8 {
     var dataSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1768,6 +2035,7 @@ pub fn decompressData(compData: []const u8) []u8 {
     return res;
 }
 
+/// Encode data to Base64 string, memory must be MemFree()
 pub fn encodeDataBase64(data: []const u8) []u8 {
     var outputSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1776,6 +2044,7 @@ pub fn encodeDataBase64(data: []const u8) []u8 {
     return res;
 }
 
+/// Decode Base64 string data, memory must be MemFree()
 pub fn decodeDataBase64(data: []const u8) []u8 {
     var outputSize: i32 = 0;
     var res: []u8 = undefined;
@@ -1788,10 +2057,12 @@ pub fn loadImageAnimFromMemory(fileType: [:0]const u8, fileData: []const u8, fra
     return cdef.LoadImageAnimFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileData)), @as(c_int, @intCast(fileData.len)), @as([*c]c_int, @ptrCast(frames)));
 }
 
+/// Load image from memory buffer, fileType refers to extension: i.e. '.png'
 pub fn loadImageFromMemory(fileType: [:0]const u8, fileData: []const u8) Image {
     return cdef.LoadImageFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileData)), @as(c_int, @intCast(fileData.len)));
 }
 
+/// Load color data from image as a Color array (RGBA - 32bit)
 pub fn loadImageColors(image: Image) RaylibError![]Color {
     var res: []Color = undefined;
 
@@ -1803,6 +2074,7 @@ pub fn loadImageColors(image: Image) RaylibError![]Color {
     return res;
 }
 
+/// Load colors palette from image as a Color array (RGBA - 32bit)
 pub fn loadImagePalette(image: Image, maxPaletteSize: i32) RaylibError![]Color {
     var colorCount: i32 = 0;
     var res: []Color = undefined;
@@ -1815,6 +2087,8 @@ pub fn loadImagePalette(image: Image, maxPaletteSize: i32) RaylibError![]Color {
     return res;
 }
 
+/// Load font from file with extended parameters, use null for codepoints and 0
+/// for codepointCount to load the default character set
 pub fn loadFontEx(fileName: [:0]const u8, fontSize: i32, fontChars: ?[]i32) Font {
     var fontCharsFinal = @as([*c]c_int, 0);
     var fontCharsLen: c_int = @as(c_int, 0);
@@ -1825,6 +2099,7 @@ pub fn loadFontEx(fileName: [:0]const u8, fontSize: i32, fontChars: ?[]i32) Font
     return cdef.LoadFontEx(@as([*c]const u8, @ptrCast(fileName)), @as(c_int, fontSize), fontCharsFinal, fontCharsLen);
 }
 
+/// Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
 pub fn loadFontFromMemory(fileType: [:0]const u8, fileData: ?[]const u8, fontSize: i32, fontChars: []i32) Font {
     var fileDataFinal = @as([*c]const u8, 0);
     var fileDataLen: i32 = 0;
@@ -1835,6 +2110,7 @@ pub fn loadFontFromMemory(fileType: [:0]const u8, fileData: ?[]const u8, fontSiz
     return cdef.LoadFontFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileDataFinal)), @as(c_int, @intCast(fileDataLen)), @as(c_int, fontSize), @as([*c]c_int, @ptrCast(fontChars)), @as(c_int, @intCast(fontChars.len)));
 }
 
+/// Load font data for further use
 pub fn loadFontData(fileData: []const u8, fontSize: i32, fontChars: []i32, ty: FontType) RaylibError![]GlyphInfo {
     var res: []GlyphInfo = undefined;
 
@@ -1846,6 +2122,7 @@ pub fn loadFontData(fileData: []const u8, fontSize: i32, fontChars: []i32, ty: F
     return res;
 }
 
+/// Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
 pub fn loadCodepoints(text: [:0]const u8) RaylibError![]i32 {
     if (@sizeOf(c_int) != @sizeOf(i32)) {
         @compileError("Can't cast pointer to c_int array to i32 because they don't have the same size");
@@ -1861,6 +2138,7 @@ pub fn loadCodepoints(text: [:0]const u8) RaylibError![]i32 {
     return res;
 }
 
+/// Text formatting with variables (sprintf() style)
 pub fn textFormat(text: [:0]const u8, args: anytype) [:0]const u8 {
     comptime {
         const info = @typeInfo(@TypeOf(args));
@@ -1871,13 +2149,14 @@ pub fn textFormat(text: [:0]const u8, args: anytype) [:0]const u8 {
             },
             else => {
                 @compileError("Args should be in a tuple (call this function like textFormat(.{arg1, arg2, ...});)!");
-            }
+            },
         }
     }
 
     return std.mem.span(@call(.auto, cdef.TextFormat, .{@as([*c]const u8, @ptrCast(text))} ++ args));
 }
 
+/// Split text into multiple strings
 pub fn textSplit(text: [:0]const u8, delimiter: u8) [][:0]const u8 {
     var count: i32 = 0;
     var res: [][:0]const u8 = undefined;
@@ -1886,10 +2165,12 @@ pub fn textSplit(text: [:0]const u8, delimiter: u8) [][:0]const u8 {
     return res;
 }
 
+/// Draw multiple mesh instances with material and different transforms
 pub fn drawMeshInstanced(mesh: Mesh, material: Material, transforms: []const Matrix) void {
     cdef.DrawMeshInstanced(mesh, material, @as([*c]const Matrix, @ptrCast(transforms)), @as(c_int, @intCast(transforms.len)));
 }
 
+/// Load materials from model file
 pub fn loadMaterials(fileName: [:0]const u8) RaylibError![]Material {
     var materialCount: i32 = 0;
     var res: []Material = undefined;
@@ -1902,6 +2183,7 @@ pub fn loadMaterials(fileName: [:0]const u8) RaylibError![]Material {
     return res;
 }
 
+/// Load model animations from file
 pub fn loadModelAnimations(fileName: [:0]const u8) RaylibError![]ModelAnimation {
     var animCount: i32 = 0;
     var res: []ModelAnimation = undefined;
@@ -1914,14 +2196,17 @@ pub fn loadModelAnimations(fileName: [:0]const u8) RaylibError![]ModelAnimation 
     return res;
 }
 
+/// Unload animation data
 pub fn unloadModelAnimations(animations: []ModelAnimation) void {
     cdef.UnloadModelAnimations(@as([*c]ModelAnimation, @ptrCast(animations)), @as(c_int, @intCast(animations.len)));
 }
 
+/// Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
 pub fn loadWaveFromMemory(fileType: [:0]const u8, fileData: []const u8) Wave {
     return cdef.LoadWaveFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(fileData)), @as(c_int, @intCast(fileData.len)));
 }
 
+/// Load samples data from wave as a 32bit float data array
 pub fn loadWaveSamples(wave: Wave) []f32 {
     var res: []f32 = undefined;
     res.ptr = @as([*]f32, @ptrCast(cdef.LoadWaveSamples(wave)));
@@ -1929,46 +2214,57 @@ pub fn loadWaveSamples(wave: Wave) []f32 {
     return res;
 }
 
+/// Load music stream from data
 pub fn loadMusicStreamFromMemory(fileType: [:0]const u8, data: []const u8) Music {
     return cdef.LoadMusicStreamFromMemory(@as([*c]const u8, @ptrCast(fileType)), @as([*c]const u8, @ptrCast(data)), @as(c_int, @intCast(data.len)));
 }
 
+/// Draw lines sequence (using gl lines)
 pub fn drawLineStrip(points: []Vector2, color: Color) void {
     cdef.DrawLineStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Draw a triangle fan defined by points (first vertex is the center)
 pub fn drawTriangleFan(points: []Vector2, color: Color) void {
     cdef.DrawTriangleFan(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Draw a triangle strip defined by points
 pub fn drawTriangleStrip(points: []Vector2, color: Color) void {
     cdef.DrawTriangleStrip(@as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Check if point is within a polygon described by array of vertices
 pub fn checkCollisionPointPoly(point: Vector2, points: []Vector2) bool {
     return cdef.CheckCollisionPointPoly(point, @as([*c]Vector2, @ptrCast(points)), @as(c_int, @intCast(points.len)));
 }
 
+/// Generate image font atlas using chars info
 pub fn genImageFontAtlas(chars: []const GlyphInfo, recs: [][]Rectangle, fontSize: i32, padding: i32, packMethod: i32) Image {
     return cdef.GenImageFontAtlas(@as([*c]const GlyphInfo, @ptrCast(chars)), @as([*c][*c]Rectangle, @ptrCast(recs)), @as(c_int, @intCast(recs.len)), @as(c_int, fontSize), @as(c_int, padding), @as(c_int, packMethod));
 }
 
+/// Unload font chars info data (RAM)
 pub fn unloadFontData(chars: []GlyphInfo) void {
     cdef.UnloadFontData(@as([*c]GlyphInfo, @ptrCast(chars)), @as(c_int, @intCast(chars.len)));
 }
 
+/// Load UTF-8 text encoded from codepoints array
 pub fn loadUTF8(codepoints: []const c_int) [:0]u8 {
     return std.mem.span(cdef.LoadUTF8(@as([*c]const c_int, @ptrCast(codepoints)), @as(c_int, @intCast(codepoints.len))));
 }
 
+/// Join text strings with delimiter
 pub fn textJoin(textList: [][:0]const u8, delimiter: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextJoin(@as([*c][*c]const u8, @ptrCast(textList)), @as(c_int, @intCast(textList.len)), @as([*c]const u8, @ptrCast(delimiter))));
 }
 
+/// Draw a triangle strip defined by points
 pub fn drawTriangleStrip3D(points: []Vector3, color: Color) void {
     cdef.DrawTriangleStrip3D(@as([*c]Vector3, @ptrCast(points)), @as(c_int, @intCast(points.len)), color);
 }
 
+/// Internal memory allocator
 fn alloc(_: *anyopaque, len: usize, _: u8, _: usize) ?[*]u8 {
     std.debug.assert(len > 0);
     return @ptrCast(cdef.MemAlloc(@intCast(len)));
@@ -1978,6 +2274,7 @@ fn resize(_: *anyopaque, buf: []u8, _: u8, new_len: usize, _: usize) bool {
     return (new_len <= buf.len);
 }
 
+/// Internal memory free
 fn free(_: *anyopaque, buf: []u8, _: u8, _: usize) void {
     cdef.MemFree(buf.ptr);
 }
@@ -1993,1077 +2290,862 @@ pub const mem = std.mem.Allocator{
     .vtable = &mem_vtable,
 };
 
-/// Initialize window and OpenGL context
 pub fn initWindow(width: i32, height: i32, title: [:0]const u8) void {
     cdef.InitWindow(@as(c_int, width), @as(c_int, height), @as([*c]const u8, @ptrCast(title)));
 }
 
-/// Close window and unload OpenGL context
 pub fn closeWindow() void {
     cdef.CloseWindow();
 }
 
-/// Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
 pub fn windowShouldClose() bool {
     return cdef.WindowShouldClose();
 }
 
-/// Check if window has been initialized successfully
 pub fn isWindowReady() bool {
     return cdef.IsWindowReady();
 }
 
-/// Check if window is currently fullscreen
 pub fn isWindowFullscreen() bool {
     return cdef.IsWindowFullscreen();
 }
 
-/// Check if window is currently hidden (only PLATFORM_DESKTOP)
 pub fn isWindowHidden() bool {
     return cdef.IsWindowHidden();
 }
 
-/// Check if window is currently minimized (only PLATFORM_DESKTOP)
 pub fn isWindowMinimized() bool {
     return cdef.IsWindowMinimized();
 }
 
-/// Check if window is currently maximized (only PLATFORM_DESKTOP)
 pub fn isWindowMaximized() bool {
     return cdef.IsWindowMaximized();
 }
 
-/// Check if window is currently focused (only PLATFORM_DESKTOP)
 pub fn isWindowFocused() bool {
     return cdef.IsWindowFocused();
 }
 
-/// Check if window has been resized last frame
 pub fn isWindowResized() bool {
     return cdef.IsWindowResized();
 }
 
-/// Check if one specific window flag is enabled
 pub fn isWindowState(flag: ConfigFlags) bool {
     return cdef.IsWindowState(flag);
 }
 
-/// Set window configuration state using flags (only PLATFORM_DESKTOP)
 pub fn setWindowState(flags: ConfigFlags) void {
     cdef.SetWindowState(flags);
 }
 
-/// Clear window configuration state flags
 pub fn clearWindowState(flags: ConfigFlags) void {
     cdef.ClearWindowState(flags);
 }
 
-/// Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
 pub fn toggleFullscreen() void {
     cdef.ToggleFullscreen();
 }
 
-/// Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
 pub fn toggleBorderlessWindowed() void {
     cdef.ToggleBorderlessWindowed();
 }
 
-/// Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 pub fn maximizeWindow() void {
     cdef.MaximizeWindow();
 }
 
-/// Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
 pub fn minimizeWindow() void {
     cdef.MinimizeWindow();
 }
 
-/// Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
 pub fn restoreWindow() void {
     cdef.RestoreWindow();
 }
 
-/// Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
 pub fn setWindowIcon(image: Image) void {
     cdef.SetWindowIcon(image);
 }
 
-/// Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
 pub fn setWindowTitle(title: [:0]const u8) void {
     cdef.SetWindowTitle(@as([*c]const u8, @ptrCast(title)));
 }
 
-/// Set window position on screen (only PLATFORM_DESKTOP)
 pub fn setWindowPosition(x: i32, y: i32) void {
     cdef.SetWindowPosition(@as(c_int, x), @as(c_int, y));
 }
 
-/// Set monitor for the current window
 pub fn setWindowMonitor(monitor: i32) void {
     cdef.SetWindowMonitor(@as(c_int, monitor));
 }
 
-/// Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 pub fn setWindowMinSize(width: i32, height: i32) void {
     cdef.SetWindowMinSize(@as(c_int, width), @as(c_int, height));
 }
 
-/// Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
 pub fn setWindowMaxSize(width: i32, height: i32) void {
     cdef.SetWindowMaxSize(@as(c_int, width), @as(c_int, height));
 }
 
-/// Set window dimensions
 pub fn setWindowSize(width: i32, height: i32) void {
     cdef.SetWindowSize(@as(c_int, width), @as(c_int, height));
 }
 
-/// Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
 pub fn setWindowOpacity(opacity: f32) void {
     cdef.SetWindowOpacity(opacity);
 }
 
-/// Set window focused (only PLATFORM_DESKTOP)
 pub fn setWindowFocused() void {
     cdef.SetWindowFocused();
 }
 
-/// Get native window handle
 pub fn getWindowHandle() *anyopaque {
     return cdef.GetWindowHandle();
 }
 
-/// Get current screen width
 pub fn getScreenWidth() i32 {
     return @as(i32, cdef.GetScreenWidth());
 }
 
-/// Get current screen height
 pub fn getScreenHeight() i32 {
     return @as(i32, cdef.GetScreenHeight());
 }
 
-/// Get current render width (it considers HiDPI)
 pub fn getRenderWidth() i32 {
     return @as(i32, cdef.GetRenderWidth());
 }
 
-/// Get current render height (it considers HiDPI)
 pub fn getRenderHeight() i32 {
     return @as(i32, cdef.GetRenderHeight());
 }
 
-/// Get number of connected monitors
 pub fn getMonitorCount() i32 {
     return @as(i32, cdef.GetMonitorCount());
 }
 
-/// Get current connected monitor
 pub fn getCurrentMonitor() i32 {
     return @as(i32, cdef.GetCurrentMonitor());
 }
 
-/// Get specified monitor position
 pub fn getMonitorPosition(monitor: i32) Vector2 {
     return cdef.GetMonitorPosition(@as(c_int, monitor));
 }
 
-/// Get specified monitor width (current video mode used by monitor)
 pub fn getMonitorWidth(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorWidth(@as(c_int, monitor)));
 }
 
-/// Get specified monitor height (current video mode used by monitor)
 pub fn getMonitorHeight(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorHeight(@as(c_int, monitor)));
 }
 
-/// Get specified monitor physical width in millimetres
 pub fn getMonitorPhysicalWidth(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorPhysicalWidth(@as(c_int, monitor)));
 }
 
-/// Get specified monitor physical height in millimetres
 pub fn getMonitorPhysicalHeight(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorPhysicalHeight(@as(c_int, monitor)));
 }
 
-/// Get specified monitor refresh rate
 pub fn getMonitorRefreshRate(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorRefreshRate(@as(c_int, monitor)));
 }
 
-/// Get window position XY on monitor
 pub fn getWindowPosition() Vector2 {
     return cdef.GetWindowPosition();
 }
 
-/// Get window scale DPI factor
 pub fn getWindowScaleDPI() Vector2 {
     return cdef.GetWindowScaleDPI();
 }
 
-/// Get the human-readable, UTF-8 encoded name of the specified monitor
 pub fn getMonitorName(monitor: i32) [:0]const u8 {
     return std.mem.span(cdef.GetMonitorName(@as(c_int, monitor)));
 }
 
-/// Set clipboard text content
 pub fn setClipboardText(text: [:0]const u8) void {
     cdef.SetClipboardText(@as([*c]const u8, @ptrCast(text)));
 }
 
-/// Get clipboard text content
 pub fn getClipboardText() [:0]const u8 {
     return std.mem.span(cdef.GetClipboardText());
 }
 
-/// Enable waiting for events on EndDrawing(), no automatic event polling
 pub fn enableEventWaiting() void {
     cdef.EnableEventWaiting();
 }
 
-/// Disable waiting for events on EndDrawing(), automatic events polling
 pub fn disableEventWaiting() void {
     cdef.DisableEventWaiting();
 }
 
-/// Shows cursor
 pub fn showCursor() void {
     cdef.ShowCursor();
 }
 
-/// Hides cursor
 pub fn hideCursor() void {
     cdef.HideCursor();
 }
 
-/// Check if cursor is not visible
 pub fn isCursorHidden() bool {
     return cdef.IsCursorHidden();
 }
 
-/// Enables cursor (unlock cursor)
 pub fn enableCursor() void {
     cdef.EnableCursor();
 }
 
-/// Disables cursor (lock cursor)
 pub fn disableCursor() void {
     cdef.DisableCursor();
 }
 
-/// Check if cursor is on the screen
 pub fn isCursorOnScreen() bool {
     return cdef.IsCursorOnScreen();
 }
 
-/// Set background color (framebuffer clear color)
 pub fn clearBackground(color: Color) void {
     cdef.ClearBackground(color);
 }
 
-/// Setup canvas (framebuffer) to start drawing
 pub fn beginDrawing() void {
     cdef.BeginDrawing();
 }
 
-/// End canvas drawing and swap buffers (double buffering)
 pub fn endDrawing() void {
     cdef.EndDrawing();
 }
 
-/// Begin 2D mode with custom camera (2D)
 pub fn beginMode2D(camera: Camera2D) void {
     cdef.BeginMode2D(camera);
 }
 
-/// Ends 2D mode with custom camera
 pub fn endMode2D() void {
     cdef.EndMode2D();
 }
 
-/// Begin 3D mode with custom camera (3D)
 pub fn beginMode3D(camera: Camera3D) void {
     cdef.BeginMode3D(camera);
 }
 
-/// Ends 3D mode and returns to default 2D orthographic mode
 pub fn endMode3D() void {
     cdef.EndMode3D();
 }
 
-/// Begin drawing to render texture
 pub fn beginTextureMode(target: RenderTexture2D) void {
     cdef.BeginTextureMode(target);
 }
 
-/// Ends drawing to render texture
 pub fn endTextureMode() void {
     cdef.EndTextureMode();
 }
 
-/// Begin custom shader drawing
 pub fn beginShaderMode(shader: Shader) void {
     cdef.BeginShaderMode(shader);
 }
 
-/// End custom shader drawing (use default shader)
 pub fn endShaderMode() void {
     cdef.EndShaderMode();
 }
 
-/// Begin blending mode (alpha, additive, multiplied, subtract, custom)
 pub fn beginBlendMode(mode: BlendMode) void {
     cdef.BeginBlendMode(mode);
 }
 
-/// End blending mode (reset to default: alpha blending)
 pub fn endBlendMode() void {
     cdef.EndBlendMode();
 }
 
-/// Begin scissor mode (define screen area for following drawing)
 pub fn beginScissorMode(x: i32, y: i32, width: i32, height: i32) void {
     cdef.BeginScissorMode(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
-/// End scissor mode
 pub fn endScissorMode() void {
     cdef.EndScissorMode();
 }
 
-/// Begin stereo rendering (requires VR simulator)
 pub fn beginVrStereoMode(config: VrStereoConfig) void {
     cdef.BeginVrStereoMode(config);
 }
 
-/// End stereo rendering (requires VR simulator)
 pub fn endVrStereoMode() void {
     cdef.EndVrStereoMode();
 }
 
-/// Load VR stereo config for VR simulator device parameters
 pub fn loadVrStereoConfig(device: VrDeviceInfo) VrStereoConfig {
     return cdef.LoadVrStereoConfig(device);
 }
 
-/// Unload VR stereo config
 pub fn unloadVrStereoConfig(config: VrStereoConfig) void {
     cdef.UnloadVrStereoConfig(config);
 }
 
-/// Check if a shader is ready
 pub fn isShaderReady(shader: Shader) bool {
     return cdef.IsShaderReady(shader);
 }
 
-/// Get shader uniform location
 pub fn getShaderLocation(shader: Shader, uniformName: [:0]const u8) i32 {
     return @as(i32, cdef.GetShaderLocation(shader, @as([*c]const u8, @ptrCast(uniformName))));
 }
 
-/// Get shader attribute location
 pub fn getShaderLocationAttrib(shader: Shader, attribName: [:0]const u8) i32 {
     return @as(i32, cdef.GetShaderLocationAttrib(shader, @as([*c]const u8, @ptrCast(attribName))));
 }
 
-/// Set shader uniform value
 pub fn setShaderValue(shader: Shader, locIndex: i32, value: *const anyopaque, uniformType: ShaderUniformDataType) void {
     cdef.SetShaderValue(shader, @as(c_int, locIndex), value, uniformType);
 }
 
-/// Set shader uniform value vector
 pub fn setShaderValueV(shader: Shader, locIndex: i32, value: *const anyopaque, uniformType: ShaderUniformDataType, count: i32) void {
     cdef.SetShaderValueV(shader, @as(c_int, locIndex), value, uniformType, @as(c_int, count));
 }
 
-/// Set shader uniform value (matrix 4x4)
 pub fn setShaderValueMatrix(shader: Shader, locIndex: i32, mat: Matrix) void {
     cdef.SetShaderValueMatrix(shader, @as(c_int, locIndex), mat);
 }
 
-/// Set shader uniform value for texture (sampler2d)
 pub fn setShaderValueTexture(shader: Shader, locIndex: i32, texture: Texture2D) void {
     cdef.SetShaderValueTexture(shader, @as(c_int, locIndex), texture);
 }
 
-/// Unload shader from GPU memory (VRAM)
 pub fn unloadShader(shader: Shader) void {
     cdef.UnloadShader(shader);
 }
 
-/// Get a ray trace from screen position (i.e mouse)
 pub fn getScreenToWorldRay(position: Vector2, camera: Camera) Ray {
     return cdef.GetScreenToWorldRay(position, camera);
 }
 
-/// Get a ray trace from screen position (i.e mouse) in a viewport
 pub fn getScreenToWorldRayEx(position: Vector2, camera: Camera, width: i32, height: i32) Ray {
     return cdef.GetScreenToWorldRayEx(position, camera, @as(c_int, width), @as(c_int, height));
 }
 
-/// Get the screen space position for a 3d world space position
 pub fn getWorldToScreen(position: Vector3, camera: Camera) Vector2 {
     return cdef.GetWorldToScreen(position, camera);
 }
 
-/// Get size position for a 3d world space position
 pub fn getWorldToScreenEx(position: Vector3, camera: Camera, width: i32, height: i32) Vector2 {
     return cdef.GetWorldToScreenEx(position, camera, @as(c_int, width), @as(c_int, height));
 }
 
-/// Get the screen space position for a 2d camera world space position
 pub fn getWorldToScreen2D(position: Vector2, camera: Camera2D) Vector2 {
     return cdef.GetWorldToScreen2D(position, camera);
 }
 
-/// Get the world space position for a 2d camera screen space position
 pub fn getScreenToWorld2D(position: Vector2, camera: Camera2D) Vector2 {
     return cdef.GetScreenToWorld2D(position, camera);
 }
 
-/// Get camera transform matrix (view matrix)
 pub fn getCameraMatrix(camera: Camera) Matrix {
     return cdef.GetCameraMatrix(camera);
 }
 
-/// Get camera 2d transform matrix
 pub fn getCameraMatrix2D(camera: Camera2D) Matrix {
     return cdef.GetCameraMatrix2D(camera);
 }
 
-/// Set target FPS (maximum)
 pub fn setTargetFPS(fps: i32) void {
     cdef.SetTargetFPS(@as(c_int, fps));
 }
 
-/// Get time in seconds for last frame drawn (delta time)
 pub fn getFrameTime() f32 {
     return cdef.GetFrameTime();
 }
 
-/// Get elapsed time in seconds since InitWindow()
 pub fn getTime() f64 {
     return cdef.GetTime();
 }
 
-/// Get current FPS
 pub fn getFPS() i32 {
     return @as(i32, cdef.GetFPS());
 }
 
-/// Swap back buffer with front buffer (screen drawing)
 pub fn swapScreenBuffer() void {
     cdef.SwapScreenBuffer();
 }
 
-/// Register all input events
 pub fn pollInputEvents() void {
     cdef.PollInputEvents();
 }
 
-/// Wait for some time (halt program execution)
 pub fn waitTime(seconds: f64) void {
     cdef.WaitTime(seconds);
 }
 
-/// Set the seed for the random number generator
 pub fn setRandomSeed(seed: u32) void {
     cdef.SetRandomSeed(@as(c_uint, seed));
 }
 
-/// Get a random value between min and max (both included)
 pub fn getRandomValue(min: i32, max: i32) i32 {
     return @as(i32, cdef.GetRandomValue(@as(c_int, min), @as(c_int, max)));
 }
 
-/// Unload random values sequence
 pub fn unloadRandomSequence(sequence: []i32) void {
     cdef.UnloadRandomSequence(@as([*c]c_int, @ptrCast(sequence)));
 }
 
-/// Takes a screenshot of current screen (filename extension defines format)
 pub fn takeScreenshot(fileName: [:0]const u8) void {
     cdef.TakeScreenshot(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Setup init configuration flags (view FLAGS)
 pub fn setConfigFlags(flags: ConfigFlags) void {
     cdef.SetConfigFlags(flags);
 }
 
-/// Open URL with default system browser (if available)
 pub fn openURL(url: [:0]const u8) void {
     cdef.OpenURL(@as([*c]const u8, @ptrCast(url)));
 }
 
-/// Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 pub fn traceLog(logLevel: TraceLogLevel, text: [:0]const u8) void {
     cdef.TraceLog(logLevel, @as([*c]const u8, @ptrCast(text)));
 }
 
-/// Set the current threshold (minimum) log level
 pub fn setTraceLogLevel(logLevel: TraceLogLevel) void {
     cdef.SetTraceLogLevel(logLevel);
 }
 
-/// Internal memory allocator
 pub fn memAlloc(size: u32) *anyopaque {
     return cdef.MemAlloc(@as(c_uint, size));
 }
 
-/// Internal memory reallocator
 pub fn memRealloc(ptr: *anyopaque, size: u32) *anyopaque {
     return cdef.MemRealloc(ptr, @as(c_uint, size));
 }
 
-/// Internal memory free
 pub fn memFree(ptr: *anyopaque) void {
     cdef.MemFree(ptr);
 }
 
-/// Set custom file binary data loader
 pub fn setLoadFileDataCallback(callback: LoadFileDataCallback) void {
     cdef.SetLoadFileDataCallback(callback);
 }
 
-/// Set custom file binary data saver
 pub fn setSaveFileDataCallback(callback: SaveFileDataCallback) void {
     cdef.SetSaveFileDataCallback(callback);
 }
 
-/// Set custom file text data loader
 pub fn setLoadFileTextCallback(callback: LoadFileTextCallback) void {
     cdef.SetLoadFileTextCallback(callback);
 }
 
-/// Set custom file text data saver
 pub fn setSaveFileTextCallback(callback: SaveFileTextCallback) void {
     cdef.SetSaveFileTextCallback(callback);
 }
 
-/// Unload file data allocated by LoadFileData()
 pub fn unloadFileData(data: []u8) void {
     cdef.UnloadFileData(@as([*c]u8, @ptrCast(data)));
 }
 
-/// Load text data from file (read), returns a '\0' terminated string
 pub fn loadFileText(fileName: [:0]const u8) [:0]u8 {
     return std.mem.span(cdef.LoadFileText(@as([*c]const u8, @ptrCast(fileName))));
 }
 
-/// Unload file text data allocated by LoadFileText()
 pub fn unloadFileText(text: [:0]u8) void {
     cdef.UnloadFileText(@as([*c]u8, @ptrCast(text)));
 }
 
-/// Save text data to file (write), string must be '\0' terminated, returns true on success
 pub fn saveFileText(fileName: [:0]const u8, text: [:0]u8) bool {
     return cdef.SaveFileText(@as([*c]const u8, @ptrCast(fileName)), @as([*c]u8, @ptrCast(text)));
 }
 
-/// Check if file exists
 pub fn fileExists(fileName: [:0]const u8) bool {
     return cdef.FileExists(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Check if a directory path exists
 pub fn directoryExists(dirPath: [:0]const u8) bool {
     return cdef.DirectoryExists(@as([*c]const u8, @ptrCast(dirPath)));
 }
 
-/// Check file extension (including point: .png, .wav)
 pub fn isFileExtension(fileName: [:0]const u8, ext: [:0]const u8) bool {
     return cdef.IsFileExtension(@as([*c]const u8, @ptrCast(fileName)), @as([*c]const u8, @ptrCast(ext)));
 }
 
-/// Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
 pub fn getFileLength(fileName: [:0]const u8) i32 {
     return @as(i32, cdef.GetFileLength(@as([*c]const u8, @ptrCast(fileName))));
 }
 
-/// Get pointer to extension for a filename string (includes dot: '.png')
 pub fn getFileExtension(fileName: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileExtension(@as([*c]const u8, @ptrCast(fileName))));
 }
 
-/// Get pointer to filename for a path string
 pub fn getFileName(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileName(@as([*c]const u8, @ptrCast(filePath))));
 }
 
-/// Get filename string without extension (uses static string)
 pub fn getFileNameWithoutExt(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileNameWithoutExt(@as([*c]const u8, @ptrCast(filePath))));
 }
 
-/// Get full path for a given fileName with path (uses static string)
 pub fn getDirectoryPath(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetDirectoryPath(@as([*c]const u8, @ptrCast(filePath))));
 }
 
-/// Get previous directory path for a given path (uses static string)
 pub fn getPrevDirectoryPath(dirPath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetPrevDirectoryPath(@as([*c]const u8, @ptrCast(dirPath))));
 }
 
-/// Get current working directory (uses static string)
 pub fn getWorkingDirectory() [:0]const u8 {
     return std.mem.span(cdef.GetWorkingDirectory());
 }
 
-/// Get the directory of the running application (uses static string)
 pub fn getApplicationDirectory() [:0]const u8 {
     return std.mem.span(cdef.GetApplicationDirectory());
 }
 
-/// Change working directory, return true on success
 pub fn changeDirectory(dir: [:0]const u8) bool {
     return cdef.ChangeDirectory(@as([*c]const u8, @ptrCast(dir)));
 }
 
-/// Check if a given path is a file or a directory
 pub fn isPathFile(path: [:0]const u8) bool {
     return cdef.IsPathFile(@as([*c]const u8, @ptrCast(path)));
 }
 
-/// Check if fileName is valid for the platform/OS
 pub fn isFileNameValid(fileName: [:0]const u8) bool {
     return cdef.IsFileNameValid(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load directory filepaths
 pub fn loadDirectoryFiles(dirPath: [:0]const u8) FilePathList {
     return cdef.LoadDirectoryFiles(@as([*c]const u8, @ptrCast(dirPath)));
 }
 
-/// Load directory filepaths with extension filtering and recursive directory scan
 pub fn loadDirectoryFilesEx(basePath: [:0]const u8, filter: [:0]const u8, scanSubdirs: bool) FilePathList {
     return cdef.LoadDirectoryFilesEx(@as([*c]const u8, @ptrCast(basePath)), @as([*c]const u8, @ptrCast(filter)), scanSubdirs);
 }
 
-/// Unload filepaths
 pub fn unloadDirectoryFiles(files: FilePathList) void {
     cdef.UnloadDirectoryFiles(files);
 }
 
-/// Check if a file has been dropped into window
 pub fn isFileDropped() bool {
     return cdef.IsFileDropped();
 }
 
-/// Load dropped filepaths
 pub fn loadDroppedFiles() FilePathList {
     return cdef.LoadDroppedFiles();
 }
 
-/// Unload dropped filepaths
 pub fn unloadDroppedFiles(files: FilePathList) void {
     cdef.UnloadDroppedFiles(files);
 }
 
-/// Get file modification time (last write time)
 pub fn getFileModTime(fileName: [:0]const u8) i64 {
     return @as(i64, cdef.GetFileModTime(@as([*c]const u8, @ptrCast(fileName))));
 }
 
-/// Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
 pub fn loadAutomationEventList(fileName: [:0]const u8) AutomationEventList {
     return cdef.LoadAutomationEventList(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Unload automation events list from file
 pub fn unloadAutomationEventList(list: AutomationEventList) void {
     cdef.UnloadAutomationEventList(list);
 }
 
-/// Export automation events list as text file
 pub fn exportAutomationEventList(list: AutomationEventList, fileName: [:0]const u8) bool {
     return cdef.ExportAutomationEventList(list, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Set automation event list to record to
 pub fn setAutomationEventList(list: *AutomationEventList) void {
     cdef.SetAutomationEventList(@as([*c]AutomationEventList, @ptrCast(list)));
 }
 
-/// Set automation event internal base frame to start recording
 pub fn setAutomationEventBaseFrame(frame: i32) void {
     cdef.SetAutomationEventBaseFrame(@as(c_int, frame));
 }
 
-/// Start recording automation events (AutomationEventList must be set)
 pub fn startAutomationEventRecording() void {
     cdef.StartAutomationEventRecording();
 }
 
-/// Stop recording automation events
 pub fn stopAutomationEventRecording() void {
     cdef.StopAutomationEventRecording();
 }
 
-/// Play a recorded automation event
 pub fn playAutomationEvent(event: AutomationEvent) void {
     cdef.PlayAutomationEvent(event);
 }
 
-/// Check if a key has been pressed once
 pub fn isKeyPressed(key: KeyboardKey) bool {
     return cdef.IsKeyPressed(key);
 }
 
-/// Check if a key has been pressed again (Only PLATFORM_DESKTOP)
 pub fn isKeyPressedRepeat(key: KeyboardKey) bool {
     return cdef.IsKeyPressedRepeat(key);
 }
 
-/// Check if a key is being pressed
 pub fn isKeyDown(key: KeyboardKey) bool {
     return cdef.IsKeyDown(key);
 }
 
-/// Check if a key has been released once
 pub fn isKeyReleased(key: KeyboardKey) bool {
     return cdef.IsKeyReleased(key);
 }
 
-/// Check if a key is NOT being pressed
 pub fn isKeyUp(key: KeyboardKey) bool {
     return cdef.IsKeyUp(key);
 }
 
-/// Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 pub fn getKeyPressed() KeyboardKey {
     return cdef.GetKeyPressed();
 }
 
-/// Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 pub fn getCharPressed() i32 {
     return @as(i32, cdef.GetCharPressed());
 }
 
-/// Set a custom key to exit program (default is ESC)
 pub fn setExitKey(key: KeyboardKey) void {
     cdef.SetExitKey(key);
 }
 
-/// Check if a gamepad is available
 pub fn isGamepadAvailable(gamepad: i32) bool {
     return cdef.IsGamepadAvailable(@as(c_int, gamepad));
 }
 
-/// Get gamepad internal name id
 pub fn getGamepadName(gamepad: i32) [:0]const u8 {
     return std.mem.span(cdef.GetGamepadName(@as(c_int, gamepad)));
 }
 
-/// Check if a gamepad button has been pressed once
 pub fn isGamepadButtonPressed(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonPressed(@as(c_int, gamepad), button);
 }
 
-/// Check if a gamepad button is being pressed
 pub fn isGamepadButtonDown(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonDown(@as(c_int, gamepad), button);
 }
 
-/// Check if a gamepad button has been released once
 pub fn isGamepadButtonReleased(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonReleased(@as(c_int, gamepad), button);
 }
 
-/// Check if a gamepad button is NOT being pressed
 pub fn isGamepadButtonUp(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonUp(@as(c_int, gamepad), button);
 }
 
-/// Get the last gamepad button pressed
 pub fn getGamepadButtonPressed() GamepadButton {
     return cdef.GetGamepadButtonPressed();
 }
 
-/// Get gamepad axis count for a gamepad
 pub fn getGamepadAxisCount(gamepad: i32) i32 {
     return @as(i32, cdef.GetGamepadAxisCount(@as(c_int, gamepad)));
 }
 
-/// Get axis movement value for a gamepad axis
 pub fn getGamepadAxisMovement(gamepad: i32, axis: i32) f32 {
     return cdef.GetGamepadAxisMovement(@as(c_int, gamepad), @as(c_int, axis));
 }
 
-/// Set internal gamepad mappings (SDL_GameControllerDB)
 pub fn setGamepadMappings(mappings: [:0]const u8) i32 {
     return @as(i32, cdef.SetGamepadMappings(@as([*c]const u8, @ptrCast(mappings))));
 }
 
-/// Set gamepad vibration for both motors
 pub fn setGamepadVibration(gamepad: i32, leftMotor: f32, rightMotor: f32) void {
     cdef.SetGamepadVibration(@as(c_int, gamepad), leftMotor, rightMotor);
 }
 
-/// Check if a mouse button has been pressed once
 pub fn isMouseButtonPressed(button: MouseButton) bool {
     return cdef.IsMouseButtonPressed(button);
 }
 
-/// Check if a mouse button is being pressed
 pub fn isMouseButtonDown(button: MouseButton) bool {
     return cdef.IsMouseButtonDown(button);
 }
 
-/// Check if a mouse button has been released once
 pub fn isMouseButtonReleased(button: MouseButton) bool {
     return cdef.IsMouseButtonReleased(button);
 }
 
-/// Check if a mouse button is NOT being pressed
 pub fn isMouseButtonUp(button: MouseButton) bool {
     return cdef.IsMouseButtonUp(button);
 }
 
-/// Get mouse position X
 pub fn getMouseX() i32 {
     return @as(i32, cdef.GetMouseX());
 }
 
-/// Get mouse position Y
 pub fn getMouseY() i32 {
     return @as(i32, cdef.GetMouseY());
 }
 
-/// Get mouse position XY
 pub fn getMousePosition() Vector2 {
     return cdef.GetMousePosition();
 }
 
-/// Get mouse delta between frames
 pub fn getMouseDelta() Vector2 {
     return cdef.GetMouseDelta();
 }
 
-/// Set mouse position XY
 pub fn setMousePosition(x: i32, y: i32) void {
     cdef.SetMousePosition(@as(c_int, x), @as(c_int, y));
 }
 
-/// Set mouse offset
 pub fn setMouseOffset(offsetX: i32, offsetY: i32) void {
     cdef.SetMouseOffset(@as(c_int, offsetX), @as(c_int, offsetY));
 }
 
-/// Set mouse scaling
 pub fn setMouseScale(scaleX: f32, scaleY: f32) void {
     cdef.SetMouseScale(scaleX, scaleY);
 }
 
-/// Get mouse wheel movement for X or Y, whichever is larger
 pub fn getMouseWheelMove() f32 {
     return cdef.GetMouseWheelMove();
 }
 
-/// Get mouse wheel movement for both X and Y
 pub fn getMouseWheelMoveV() Vector2 {
     return cdef.GetMouseWheelMoveV();
 }
 
-/// Set mouse cursor
 pub fn setMouseCursor(cursor: i32) void {
     cdef.SetMouseCursor(@as(c_int, cursor));
 }
 
-/// Get touch position X for touch point 0 (relative to screen size)
 pub fn getTouchX() i32 {
     return @as(i32, cdef.GetTouchX());
 }
 
-/// Get touch position Y for touch point 0 (relative to screen size)
 pub fn getTouchY() i32 {
     return @as(i32, cdef.GetTouchY());
 }
 
-/// Get touch position XY for a touch point index (relative to screen size)
 pub fn getTouchPosition(index: i32) Vector2 {
     return cdef.GetTouchPosition(@as(c_int, index));
 }
 
-/// Get touch point identifier for given index
 pub fn getTouchPointId(index: i32) i32 {
     return @as(i32, cdef.GetTouchPointId(@as(c_int, index)));
 }
 
-/// Get number of touch points
 pub fn getTouchPointCount() i32 {
     return @as(i32, cdef.GetTouchPointCount());
 }
 
-/// Enable a set of gestures using flags
 pub fn setGesturesEnabled(flags: Gesture) void {
     cdef.SetGesturesEnabled(flags);
 }
 
-/// Check if a gesture have been detected
 pub fn isGestureDetected(gesture: Gesture) bool {
     return cdef.IsGestureDetected(gesture);
 }
 
-/// Get latest detected gesture
 pub fn getGestureDetected() Gesture {
     return cdef.GetGestureDetected();
 }
 
-/// Get gesture hold time in milliseconds
 pub fn getGestureHoldDuration() f32 {
     return cdef.GetGestureHoldDuration();
 }
 
-/// Get gesture drag vector
 pub fn getGestureDragVector() Vector2 {
     return cdef.GetGestureDragVector();
 }
 
-/// Get gesture drag angle
 pub fn getGestureDragAngle() f32 {
     return cdef.GetGestureDragAngle();
 }
 
-/// Get gesture pinch delta
 pub fn getGesturePinchVector() Vector2 {
     return cdef.GetGesturePinchVector();
 }
 
-/// Get gesture pinch angle
 pub fn getGesturePinchAngle() f32 {
     return cdef.GetGesturePinchAngle();
 }
 
-/// Update camera position for selected mode
 pub fn updateCamera(camera: *Camera, mode: CameraMode) void {
     cdef.UpdateCamera(@as([*c]Camera, @ptrCast(camera)), mode);
 }
 
-/// Update camera movement/rotation
 pub fn updateCameraPro(camera: *Camera, movement: Vector3, rotation: Vector3, zoom: f32) void {
     cdef.UpdateCameraPro(@as([*c]Camera, @ptrCast(camera)), movement, rotation, zoom);
 }
 
-/// Set texture and rectangle to be used on shapes drawing
 pub fn setShapesTexture(texture: Texture2D, source: Rectangle) void {
     cdef.SetShapesTexture(texture, source);
 }
 
-/// Get texture that is used for shapes drawing
 pub fn getShapesTexture() Texture2D {
     return cdef.GetShapesTexture();
 }
 
-/// Get texture source rectangle that is used for shapes drawing
 pub fn getShapesTextureRectangle() Rectangle {
     return cdef.GetShapesTextureRectangle();
 }
 
-/// Draw a pixel
 pub fn drawPixel(posX: i32, posY: i32, color: Color) void {
     cdef.DrawPixel(@as(c_int, posX), @as(c_int, posY), color);
 }
 
-/// Draw a pixel (Vector version)
 pub fn drawPixelV(position: Vector2, color: Color) void {
     cdef.DrawPixelV(position, color);
 }
 
-/// Draw a line
 pub fn drawLine(startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
     cdef.DrawLine(@as(c_int, startPosX), @as(c_int, startPosY), @as(c_int, endPosX), @as(c_int, endPosY), color);
 }
 
-/// Draw a line (using gl lines)
 pub fn drawLineV(startPos: Vector2, endPos: Vector2, color: Color) void {
     cdef.DrawLineV(startPos, endPos, color);
 }
 
-/// Draw a line (using triangles/quads)
 pub fn drawLineEx(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) void {
     cdef.DrawLineEx(startPos, endPos, thick, color);
 }
 
-/// Draw line segment cubic-bezier in-out interpolation
 pub fn drawLineBezier(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) void {
     cdef.DrawLineBezier(startPos, endPos, thick, color);
 }
 
-/// Draw a color-filled circle
 pub fn drawCircle(centerX: i32, centerY: i32, radius: f32, color: Color) void {
     cdef.DrawCircle(@as(c_int, centerX), @as(c_int, centerY), radius, color);
 }
 
-/// Draw a piece of a circle
 pub fn drawCircleSector(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawCircleSector(center, radius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
-/// Draw circle sector outline
 pub fn drawCircleSectorLines(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawCircleSectorLines(center, radius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
-/// Draw a gradient-filled circle
 pub fn drawCircleGradient(centerX: i32, centerY: i32, radius: f32, color1: Color, color2: Color) void {
     cdef.DrawCircleGradient(@as(c_int, centerX), @as(c_int, centerY), radius, color1, color2);
 }
 
-/// Draw a color-filled circle (Vector version)
 pub fn drawCircleV(center: Vector2, radius: f32, color: Color) void {
     cdef.DrawCircleV(center, radius, color);
 }
 
-/// Draw circle outline
 pub fn drawCircleLines(centerX: i32, centerY: i32, radius: f32, color: Color) void {
     cdef.DrawCircleLines(@as(c_int, centerX), @as(c_int, centerY), radius, color);
 }
 
-/// Draw circle outline (Vector version)
 pub fn drawCircleLinesV(center: Vector2, radius: f32, color: Color) void {
     cdef.DrawCircleLinesV(center, radius, color);
 }
 
-/// Draw ellipse
 pub fn drawEllipse(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) void {
     cdef.DrawEllipse(@as(c_int, centerX), @as(c_int, centerY), radiusH, radiusV, color);
 }
 
-/// Draw ellipse outline
 pub fn drawEllipseLines(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) void {
     cdef.DrawEllipseLines(@as(c_int, centerX), @as(c_int, centerY), radiusH, radiusV, color);
 }
 
-/// Draw ring
 pub fn drawRing(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawRing(center, innerRadius, outerRadius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
-/// Draw ring outline
 pub fn drawRingLines(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawRingLines(center, innerRadius, outerRadius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
-/// Draw a color-filled rectangle
 pub fn drawRectangle(posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.DrawRectangle(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
-/// Draw a color-filled rectangle (Vector version)
 pub fn drawRectangleV(position: Vector2, size: Vector2, color: Color) void {
     cdef.DrawRectangleV(position, size, color);
 }
 
-/// Draw a color-filled rectangle
 pub fn drawRectangleRec(rec: Rectangle, color: Color) void {
     cdef.DrawRectangleRec(rec, color);
 }
 
-/// Draw a color-filled rectangle with pro parameters
 pub fn drawRectanglePro(rec: Rectangle, origin: Vector2, rotation: f32, color: Color) void {
     cdef.DrawRectanglePro(rec, origin, rotation, color);
 }
@@ -3078,1552 +3160,1242 @@ pub fn drawRectangleGradientH(posX: i32, posY: i32, width: i32, height: i32, col
     cdef.DrawRectangleGradientH(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color1, color2);
 }
 
-/// Draw a gradient-filled rectangle with custom vertex colors
 pub fn drawRectangleGradientEx(rec: Rectangle, col1: Color, col2: Color, col3: Color, col4: Color) void {
     cdef.DrawRectangleGradientEx(rec, col1, col2, col3, col4);
 }
 
-/// Draw rectangle outline
 pub fn drawRectangleLines(posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.DrawRectangleLines(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
-/// Draw rectangle outline with extended parameters
 pub fn drawRectangleLinesEx(rec: Rectangle, lineThick: f32, color: Color) void {
     cdef.DrawRectangleLinesEx(rec, lineThick, color);
 }
 
-/// Draw rectangle with rounded edges
 pub fn drawRectangleRounded(rec: Rectangle, roundness: f32, segments: i32, color: Color) void {
     cdef.DrawRectangleRounded(rec, roundness, @as(c_int, segments), color);
 }
 
-/// Draw rectangle lines with rounded edges
 pub fn drawRectangleRoundedLines(rec: Rectangle, roundness: f32, segments: i32, color: Color) void {
     cdef.DrawRectangleRoundedLines(rec, roundness, @as(c_int, segments), color);
 }
 
-/// Draw rectangle with rounded edges outline
 pub fn drawRectangleRoundedLinesEx(rec: Rectangle, roundness: f32, segments: i32, lineThick: f32, color: Color) void {
     cdef.DrawRectangleRoundedLinesEx(rec, roundness, @as(c_int, segments), lineThick, color);
 }
 
-/// Draw a color-filled triangle (vertex in counter-clockwise order!)
 pub fn drawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) void {
     cdef.DrawTriangle(v1, v2, v3, color);
 }
 
-/// Draw triangle outline (vertex in counter-clockwise order!)
 pub fn drawTriangleLines(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) void {
     cdef.DrawTriangleLines(v1, v2, v3, color);
 }
 
-/// Draw a regular polygon (Vector version)
 pub fn drawPoly(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) void {
     cdef.DrawPoly(center, @as(c_int, sides), radius, rotation, color);
 }
 
-/// Draw a polygon outline of n sides
 pub fn drawPolyLines(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) void {
     cdef.DrawPolyLines(center, @as(c_int, sides), radius, rotation, color);
 }
 
-/// Draw a polygon outline of n sides with extended parameters
 pub fn drawPolyLinesEx(center: Vector2, sides: i32, radius: f32, rotation: f32, lineThick: f32, color: Color) void {
     cdef.DrawPolyLinesEx(center, @as(c_int, sides), radius, rotation, lineThick, color);
 }
 
-/// Draw spline: Linear, minimum 2 points
 pub fn drawSplineLinear(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineLinear(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
-/// Draw spline: B-Spline, minimum 4 points
 pub fn drawSplineBasis(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBasis(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
-/// Draw spline: Catmull-Rom, minimum 4 points
 pub fn drawSplineCatmullRom(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineCatmullRom(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
-/// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
 pub fn drawSplineBezierQuadratic(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBezierQuadratic(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
-/// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
 pub fn drawSplineBezierCubic(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBezierCubic(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
-/// Draw spline segment: Linear, 2 points
 pub fn drawSplineSegmentLinear(p1: Vector2, p2: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentLinear(p1, p2, thick, color);
 }
 
-/// Draw spline segment: B-Spline, 4 points
 pub fn drawSplineSegmentBasis(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBasis(p1, p2, p3, p4, thick, color);
 }
 
-/// Draw spline segment: Catmull-Rom, 4 points
 pub fn drawSplineSegmentCatmullRom(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentCatmullRom(p1, p2, p3, p4, thick, color);
 }
 
-/// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
 pub fn drawSplineSegmentBezierQuadratic(p1: Vector2, c2: Vector2, p3: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBezierQuadratic(p1, c2, p3, thick, color);
 }
 
-/// Draw spline segment: Cubic Bezier, 2 points, 2 control points
 pub fn drawSplineSegmentBezierCubic(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBezierCubic(p1, c2, c3, p4, thick, color);
 }
 
-/// Get (evaluate) spline point: Linear
 pub fn getSplinePointLinear(startPos: Vector2, endPos: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointLinear(startPos, endPos, t);
 }
 
-/// Get (evaluate) spline point: B-Spline
 pub fn getSplinePointBasis(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBasis(p1, p2, p3, p4, t);
 }
 
-/// Get (evaluate) spline point: Catmull-Rom
 pub fn getSplinePointCatmullRom(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointCatmullRom(p1, p2, p3, p4, t);
 }
 
-/// Get (evaluate) spline point: Quadratic Bezier
 pub fn getSplinePointBezierQuad(p1: Vector2, c2: Vector2, p3: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBezierQuad(p1, c2, p3, t);
 }
 
-/// Get (evaluate) spline point: Cubic Bezier
 pub fn getSplinePointBezierCubic(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBezierCubic(p1, c2, c3, p4, t);
 }
 
-/// Check collision between two rectangles
 pub fn checkCollisionRecs(rec1: Rectangle, rec2: Rectangle) bool {
     return cdef.CheckCollisionRecs(rec1, rec2);
 }
 
-/// Check collision between two circles
 pub fn checkCollisionCircles(center1: Vector2, radius1: f32, center2: Vector2, radius2: f32) bool {
     return cdef.CheckCollisionCircles(center1, radius1, center2, radius2);
 }
 
-/// Check collision between circle and rectangle
 pub fn checkCollisionCircleRec(center: Vector2, radius: f32, rec: Rectangle) bool {
     return cdef.CheckCollisionCircleRec(center, radius, rec);
 }
 
-/// Check if point is inside rectangle
 pub fn checkCollisionPointRec(point: Vector2, rec: Rectangle) bool {
     return cdef.CheckCollisionPointRec(point, rec);
 }
 
-/// Check if point is inside circle
 pub fn checkCollisionPointCircle(point: Vector2, center: Vector2, radius: f32) bool {
     return cdef.CheckCollisionPointCircle(point, center, radius);
 }
 
-/// Check if point is inside a triangle
 pub fn checkCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) bool {
     return cdef.CheckCollisionPointTriangle(point, p1, p2, p3);
 }
 
-/// Check the collision between two lines defined by two points each, returns collision point by reference
 pub fn checkCollisionLines(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: *Vector2) bool {
     return cdef.CheckCollisionLines(startPos1, endPos1, startPos2, endPos2, @as([*c]Vector2, @ptrCast(collisionPoint)));
 }
 
-/// Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
 pub fn checkCollisionPointLine(point: Vector2, p1: Vector2, p2: Vector2, threshold: i32) bool {
     return cdef.CheckCollisionPointLine(point, p1, p2, @as(c_int, threshold));
 }
 
-/// Check if circle collides with a line created betweeen two points [p1] and [p2]
 pub fn checkCollisionCircleLine(center: Vector2, radius: f32, p1: Vector2, p2: Vector2) bool {
     return cdef.CheckCollisionCircleLine(center, radius, p1, p2);
 }
 
-/// Get collision rectangle for two rectangles collision
 pub fn getCollisionRec(rec1: Rectangle, rec2: Rectangle) Rectangle {
     return cdef.GetCollisionRec(rec1, rec2);
 }
 
-/// Load image from file into CPU memory (RAM)
 pub fn loadImage(fileName: [:0]const u8) Image {
     return cdef.LoadImage(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load image from RAW file data
 pub fn loadImageRaw(fileName: [:0]const u8, width: i32, height: i32, format: PixelFormat, headerSize: i32) Image {
     return cdef.LoadImageRaw(@as([*c]const u8, @ptrCast(fileName)), @as(c_int, width), @as(c_int, height), format, @as(c_int, headerSize));
 }
 
-/// Load image from SVG file data or string with specified size
 pub fn loadImageSvg(fileNameOrString: [:0]const u8, width: i32, height: i32) Image {
     return cdef.LoadImageSvg(@as([*c]const u8, @ptrCast(fileNameOrString)), @as(c_int, width), @as(c_int, height));
 }
 
-/// Load image sequence from file (frames appended to image.data)
 pub fn loadImageAnim(fileName: [:0]const u8, frames: *i32) Image {
     return cdef.LoadImageAnim(@as([*c]const u8, @ptrCast(fileName)), @as([*c]c_int, @ptrCast(frames)));
 }
 
-/// Load image from GPU texture data
 pub fn loadImageFromTexture(texture: Texture2D) Image {
     return cdef.LoadImageFromTexture(texture);
 }
 
-/// Load image from screen buffer and (screenshot)
 pub fn loadImageFromScreen() Image {
     return cdef.LoadImageFromScreen();
 }
 
-/// Check if an image is ready
 pub fn isImageReady(image: Image) bool {
     return cdef.IsImageReady(image);
 }
 
-/// Unload image from CPU memory (RAM)
 pub fn unloadImage(image: Image) void {
     cdef.UnloadImage(image);
 }
 
-/// Export image data to file, returns true on success
 pub fn exportImage(image: Image, fileName: [:0]const u8) bool {
     return cdef.ExportImage(image, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Export image to memory buffer
 pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) [:0]u8 {
     return std.mem.span(cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize))));
 }
 
-/// Export image as code file defining an array of bytes, returns true on success
 pub fn exportImageAsCode(image: Image, fileName: [:0]const u8) bool {
     return cdef.ExportImageAsCode(image, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Generate image: plain color
 pub fn genImageColor(width: i32, height: i32, color: Color) Image {
     return cdef.GenImageColor(@as(c_int, width), @as(c_int, height), color);
 }
 
-/// Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
 pub fn genImageGradientLinear(width: i32, height: i32, direction: i32, start: Color, end: Color) Image {
     return cdef.GenImageGradientLinear(@as(c_int, width), @as(c_int, height), @as(c_int, direction), start, end);
 }
 
-/// Generate image: radial gradient
 pub fn genImageGradientRadial(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
     return cdef.GenImageGradientRadial(@as(c_int, width), @as(c_int, height), density, inner, outer);
 }
 
-/// Generate image: square gradient
 pub fn genImageGradientSquare(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
     return cdef.GenImageGradientSquare(@as(c_int, width), @as(c_int, height), density, inner, outer);
 }
 
-/// Generate image: checked
 pub fn genImageChecked(width: i32, height: i32, checksX: i32, checksY: i32, col1: Color, col2: Color) Image {
     return cdef.GenImageChecked(@as(c_int, width), @as(c_int, height), @as(c_int, checksX), @as(c_int, checksY), col1, col2);
 }
 
-/// Generate image: white noise
 pub fn genImageWhiteNoise(width: i32, height: i32, factor: f32) Image {
     return cdef.GenImageWhiteNoise(@as(c_int, width), @as(c_int, height), factor);
 }
 
-/// Generate image: perlin noise
 pub fn genImagePerlinNoise(width: i32, height: i32, offsetX: i32, offsetY: i32, scale: f32) Image {
     return cdef.GenImagePerlinNoise(@as(c_int, width), @as(c_int, height), @as(c_int, offsetX), @as(c_int, offsetY), scale);
 }
 
-/// Generate image: cellular algorithm, bigger tileSize means bigger cells
 pub fn genImageCellular(width: i32, height: i32, tileSize: i32) Image {
     return cdef.GenImageCellular(@as(c_int, width), @as(c_int, height), @as(c_int, tileSize));
 }
 
-/// Generate image: grayscale image from text data
 pub fn genImageText(width: i32, height: i32, text: [:0]const u8) Image {
     return cdef.GenImageText(@as(c_int, width), @as(c_int, height), @as([*c]const u8, @ptrCast(text)));
 }
 
-/// Create an image duplicate (useful for transformations)
 pub fn imageCopy(image: Image) Image {
     return cdef.ImageCopy(image);
 }
 
-/// Create an image from another image piece
 pub fn imageFromImage(image: Image, rec: Rectangle) Image {
     return cdef.ImageFromImage(image, rec);
 }
 
-/// Create an image from text (default font)
 pub fn imageText(text: [:0]const u8, fontSize: i32, color: Color) Image {
     return cdef.ImageText(@as([*c]const u8, @ptrCast(text)), @as(c_int, fontSize), color);
 }
 
-/// Create an image from text (custom sprite font)
 pub fn imageTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32, tint: Color) Image {
     return cdef.ImageTextEx(font, @as([*c]const u8, @ptrCast(text)), fontSize, spacing, tint);
 }
 
-/// Convert image data to desired format
 pub fn imageFormat(image: *Image, newFormat: PixelFormat) void {
     cdef.ImageFormat(@as([*c]Image, @ptrCast(image)), newFormat);
 }
 
-/// Convert image to POT (power-of-two)
 pub fn imageToPOT(image: *Image, fill: Color) void {
     cdef.ImageToPOT(@as([*c]Image, @ptrCast(image)), fill);
 }
 
-/// Crop an image to a defined rectangle
 pub fn imageCrop(image: *Image, crop: Rectangle) void {
     cdef.ImageCrop(@as([*c]Image, @ptrCast(image)), crop);
 }
 
-/// Crop image depending on alpha value
 pub fn imageAlphaCrop(image: *Image, threshold: f32) void {
     cdef.ImageAlphaCrop(@as([*c]Image, @ptrCast(image)), threshold);
 }
 
-/// Clear alpha channel to desired color
 pub fn imageAlphaClear(image: *Image, color: Color, threshold: f32) void {
     cdef.ImageAlphaClear(@as([*c]Image, @ptrCast(image)), color, threshold);
 }
 
-/// Apply alpha mask to image
 pub fn imageAlphaMask(image: *Image, alphaMask: Image) void {
     cdef.ImageAlphaMask(@as([*c]Image, @ptrCast(image)), alphaMask);
 }
 
-/// Premultiply alpha channel
 pub fn imageAlphaPremultiply(image: *Image) void {
     cdef.ImageAlphaPremultiply(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Apply Gaussian blur using a box blur approximation
 pub fn imageBlurGaussian(image: *Image, blurSize: i32) void {
     cdef.ImageBlurGaussian(@as([*c]Image, @ptrCast(image)), @as(c_int, blurSize));
 }
 
-/// Apply Custom Square image convolution kernel
 pub fn imageKernelConvolution(image: *Image, kernel: []f32, kernelSize: i32) void {
     cdef.ImageKernelConvolution(@as([*c]Image, @ptrCast(image)), @as([*c]f32, @ptrCast(kernel)), @as(c_int, kernelSize));
 }
 
-/// Resize image (Bicubic scaling algorithm)
 pub fn imageResize(image: *Image, newWidth: i32, newHeight: i32) void {
     cdef.ImageResize(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight));
 }
 
-/// Resize image (Nearest-Neighbor scaling algorithm)
 pub fn imageResizeNN(image: *Image, newWidth: i32, newHeight: i32) void {
     cdef.ImageResizeNN(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight));
 }
 
-/// Resize canvas and fill with color
 pub fn imageResizeCanvas(image: *Image, newWidth: i32, newHeight: i32, offsetX: i32, offsetY: i32, fill: Color) void {
     cdef.ImageResizeCanvas(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight), @as(c_int, offsetX), @as(c_int, offsetY), fill);
 }
 
-/// Compute all mipmap levels for a provided image
 pub fn imageMipmaps(image: *Image) void {
     cdef.ImageMipmaps(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
 pub fn imageDither(image: *Image, rBpp: i32, gBpp: i32, bBpp: i32, aBpp: i32) void {
     cdef.ImageDither(@as([*c]Image, @ptrCast(image)), @as(c_int, rBpp), @as(c_int, gBpp), @as(c_int, bBpp), @as(c_int, aBpp));
 }
 
-/// Flip image vertically
 pub fn imageFlipVertical(image: *Image) void {
     cdef.ImageFlipVertical(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Flip image horizontally
 pub fn imageFlipHorizontal(image: *Image) void {
     cdef.ImageFlipHorizontal(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Rotate image by input angle in degrees (-359 to 359)
 pub fn imageRotate(image: *Image, degrees: i32) void {
     cdef.ImageRotate(@as([*c]Image, @ptrCast(image)), @as(c_int, degrees));
 }
 
-/// Rotate image clockwise 90deg
 pub fn imageRotateCW(image: *Image) void {
     cdef.ImageRotateCW(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Rotate image counter-clockwise 90deg
 pub fn imageRotateCCW(image: *Image) void {
     cdef.ImageRotateCCW(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Modify image color: tint
 pub fn imageColorTint(image: *Image, color: Color) void {
     cdef.ImageColorTint(@as([*c]Image, @ptrCast(image)), color);
 }
 
-/// Modify image color: invert
 pub fn imageColorInvert(image: *Image) void {
     cdef.ImageColorInvert(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Modify image color: grayscale
 pub fn imageColorGrayscale(image: *Image) void {
     cdef.ImageColorGrayscale(@as([*c]Image, @ptrCast(image)));
 }
 
-/// Modify image color: contrast (-100 to 100)
 pub fn imageColorContrast(image: *Image, contrast: f32) void {
     cdef.ImageColorContrast(@as([*c]Image, @ptrCast(image)), contrast);
 }
 
-/// Modify image color: brightness (-255 to 255)
 pub fn imageColorBrightness(image: *Image, brightness: i32) void {
     cdef.ImageColorBrightness(@as([*c]Image, @ptrCast(image)), @as(c_int, brightness));
 }
 
-/// Modify image color: replace color
 pub fn imageColorReplace(image: *Image, color: Color, replace: Color) void {
     cdef.ImageColorReplace(@as([*c]Image, @ptrCast(image)), color, replace);
 }
 
-/// Unload color data loaded with LoadImageColors()
 pub fn unloadImageColors(colors: []Color) void {
     cdef.UnloadImageColors(@as([*c]Color, @ptrCast(colors)));
 }
 
-/// Unload colors palette loaded with LoadImagePalette()
 pub fn unloadImagePalette(colors: []Color) void {
     cdef.UnloadImagePalette(@as([*c]Color, @ptrCast(colors)));
 }
 
-/// Get image alpha border rectangle
 pub fn getImageAlphaBorder(image: Image, threshold: f32) Rectangle {
     return cdef.GetImageAlphaBorder(image, threshold);
 }
 
-/// Get image pixel color at (x, y) position
 pub fn getImageColor(image: Image, x: i32, y: i32) Color {
     return cdef.GetImageColor(image, @as(c_int, x), @as(c_int, y));
 }
 
-/// Clear image background with given color
 pub fn imageClearBackground(dst: *Image, color: Color) void {
     cdef.ImageClearBackground(@as([*c]Image, @ptrCast(dst)), color);
 }
 
-/// Draw pixel within an image
 pub fn imageDrawPixel(dst: *Image, posX: i32, posY: i32, color: Color) void {
     cdef.ImageDrawPixel(@as([*c]Image, @ptrCast(dst)), @as(c_int, posX), @as(c_int, posY), color);
 }
 
-/// Draw pixel within an image (Vector version)
 pub fn imageDrawPixelV(dst: *Image, position: Vector2, color: Color) void {
     cdef.ImageDrawPixelV(@as([*c]Image, @ptrCast(dst)), position, color);
 }
 
-/// Draw line within an image
 pub fn imageDrawLine(dst: *Image, startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
     cdef.ImageDrawLine(@as([*c]Image, @ptrCast(dst)), @as(c_int, startPosX), @as(c_int, startPosY), @as(c_int, endPosX), @as(c_int, endPosY), color);
 }
 
-/// Draw line within an image (Vector version)
 pub fn imageDrawLineV(dst: *Image, start: Vector2, end: Vector2, color: Color) void {
     cdef.ImageDrawLineV(@as([*c]Image, @ptrCast(dst)), start, end, color);
 }
 
-/// Draw a filled circle within an image
 pub fn imageDrawCircle(dst: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
     cdef.ImageDrawCircle(@as([*c]Image, @ptrCast(dst)), @as(c_int, centerX), @as(c_int, centerY), @as(c_int, radius), color);
 }
 
-/// Draw a filled circle within an image (Vector version)
 pub fn imageDrawCircleV(dst: *Image, center: Vector2, radius: i32, color: Color) void {
     cdef.ImageDrawCircleV(@as([*c]Image, @ptrCast(dst)), center, @as(c_int, radius), color);
 }
 
-/// Draw circle outline within an image
 pub fn imageDrawCircleLines(dst: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
     cdef.ImageDrawCircleLines(@as([*c]Image, @ptrCast(dst)), @as(c_int, centerX), @as(c_int, centerY), @as(c_int, radius), color);
 }
 
-/// Draw circle outline within an image (Vector version)
 pub fn imageDrawCircleLinesV(dst: *Image, center: Vector2, radius: i32, color: Color) void {
     cdef.ImageDrawCircleLinesV(@as([*c]Image, @ptrCast(dst)), center, @as(c_int, radius), color);
 }
 
-/// Draw rectangle within an image
 pub fn imageDrawRectangle(dst: *Image, posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.ImageDrawRectangle(@as([*c]Image, @ptrCast(dst)), @as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
-/// Draw rectangle within an image (Vector version)
 pub fn imageDrawRectangleV(dst: *Image, position: Vector2, size: Vector2, color: Color) void {
     cdef.ImageDrawRectangleV(@as([*c]Image, @ptrCast(dst)), position, size, color);
 }
 
-/// Draw rectangle within an image
 pub fn imageDrawRectangleRec(dst: *Image, rec: Rectangle, color: Color) void {
     cdef.ImageDrawRectangleRec(@as([*c]Image, @ptrCast(dst)), rec, color);
 }
 
-/// Draw rectangle lines within an image
 pub fn imageDrawRectangleLines(dst: *Image, rec: Rectangle, thick: i32, color: Color) void {
     cdef.ImageDrawRectangleLines(@as([*c]Image, @ptrCast(dst)), rec, @as(c_int, thick), color);
 }
 
-/// Draw a source image within a destination image (tint applied to source)
 pub fn imageDraw(dst: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color) void {
     cdef.ImageDraw(@as([*c]Image, @ptrCast(dst)), src, srcRec, dstRec, tint);
 }
 
-/// Draw text (using default font) within an image (destination)
 pub fn imageDrawText(dst: *Image, text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
     cdef.ImageDrawText(@as([*c]Image, @ptrCast(dst)), @as([*c]const u8, @ptrCast(text)), @as(c_int, posX), @as(c_int, posY), @as(c_int, fontSize), color);
 }
 
-/// Draw text (custom sprite font) within an image (destination)
 pub fn imageDrawTextEx(dst: *Image, font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.ImageDrawTextEx(@as([*c]Image, @ptrCast(dst)), font, @as([*c]const u8, @ptrCast(text)), position, fontSize, spacing, tint);
 }
 
-/// Load texture from file into GPU memory (VRAM)
 pub fn loadTexture(fileName: [:0]const u8) Texture2D {
     return cdef.LoadTexture(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load texture from image data
 pub fn loadTextureFromImage(image: Image) Texture2D {
     return cdef.LoadTextureFromImage(image);
 }
 
-/// Load cubemap from image, multiple image cubemap layouts supported
 pub fn loadTextureCubemap(image: Image, layout: CubemapLayout) TextureCubemap {
     return cdef.LoadTextureCubemap(image, layout);
 }
 
-/// Load texture for rendering (framebuffer)
 pub fn loadRenderTexture(width: i32, height: i32) RenderTexture2D {
     return cdef.LoadRenderTexture(@as(c_int, width), @as(c_int, height));
 }
 
-/// Check if a texture is ready
 pub fn isTextureReady(texture: Texture2D) bool {
     return cdef.IsTextureReady(texture);
 }
 
-/// Unload texture from GPU memory (VRAM)
 pub fn unloadTexture(texture: Texture2D) void {
     cdef.UnloadTexture(texture);
 }
 
-/// Check if a render texture is ready
 pub fn isRenderTextureReady(target: RenderTexture2D) bool {
     return cdef.IsRenderTextureReady(target);
 }
 
-/// Unload render texture from GPU memory (VRAM)
 pub fn unloadRenderTexture(target: RenderTexture2D) void {
     cdef.UnloadRenderTexture(target);
 }
 
-/// Update GPU texture with new data
 pub fn updateTexture(texture: Texture2D, pixels: *const anyopaque) void {
     cdef.UpdateTexture(texture, pixels);
 }
 
-/// Update GPU texture rectangle with new data
 pub fn updateTextureRec(texture: Texture2D, rec: Rectangle, pixels: *const anyopaque) void {
     cdef.UpdateTextureRec(texture, rec, pixels);
 }
 
-/// Generate GPU mipmaps for a texture
 pub fn genTextureMipmaps(texture: *Texture2D) void {
     cdef.GenTextureMipmaps(@as([*c]Texture2D, @ptrCast(texture)));
 }
 
-/// Set texture scaling filter mode
 pub fn setTextureFilter(texture: Texture2D, filter: TextureFilter) void {
     cdef.SetTextureFilter(texture, filter);
 }
 
-/// Set texture wrapping mode
 pub fn setTextureWrap(texture: Texture2D, wrap: i32) void {
     cdef.SetTextureWrap(texture, @as(c_int, wrap));
 }
 
-/// Draw a Texture2D
 pub fn drawTexture(texture: Texture2D, posX: i32, posY: i32, tint: Color) void {
     cdef.DrawTexture(texture, @as(c_int, posX), @as(c_int, posY), tint);
 }
 
-/// Draw a Texture2D with position defined as Vector2
 pub fn drawTextureV(texture: Texture2D, position: Vector2, tint: Color) void {
     cdef.DrawTextureV(texture, position, tint);
 }
 
-/// Draw a Texture2D with extended parameters
 pub fn drawTextureEx(texture: Texture2D, position: Vector2, rotation: f32, scale: f32, tint: Color) void {
     cdef.DrawTextureEx(texture, position, rotation, scale, tint);
 }
 
-/// Draw a part of a texture defined by a rectangle
 pub fn drawTextureRec(texture: Texture2D, source: Rectangle, position: Vector2, tint: Color) void {
     cdef.DrawTextureRec(texture, source, position, tint);
 }
 
-/// Draw a part of a texture defined by a rectangle with 'pro' parameters
 pub fn drawTexturePro(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawTexturePro(texture, source, dest, origin, rotation, tint);
 }
 
-/// Draws a texture (or part of it) that stretches or shrinks nicely
 pub fn drawTextureNPatch(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawTextureNPatch(texture, nPatchInfo, dest, origin, rotation, tint);
 }
 
-/// Check if two colors are equal
 pub fn colorIsEqual(col1: Color, col2: Color) bool {
     return cdef.ColorIsEqual(col1, col2);
 }
 
-/// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn fade(color: Color, alpha: f32) Color {
     return cdef.Fade(color, alpha);
 }
 
-/// Get hexadecimal value for a Color (0xRRGGBBAA)
 pub fn colorToInt(color: Color) i32 {
     return @as(i32, cdef.ColorToInt(color));
 }
 
-/// Get Color normalized as float [0..1]
 pub fn colorNormalize(color: Color) Vector4 {
     return cdef.ColorNormalize(color);
 }
 
-/// Get Color from normalized values [0..1]
 pub fn colorFromNormalized(normalized: Vector4) Color {
     return cdef.ColorFromNormalized(normalized);
 }
 
-/// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
 pub fn colorToHSV(color: Color) Vector3 {
     return cdef.ColorToHSV(color);
 }
 
-/// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
 pub fn colorFromHSV(hue: f32, saturation: f32, value: f32) Color {
     return cdef.ColorFromHSV(hue, saturation, value);
 }
 
-/// Get color multiplied with another color
 pub fn colorTint(color: Color, tint: Color) Color {
     return cdef.ColorTint(color, tint);
 }
 
-/// Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
 pub fn colorBrightness(color: Color, factor: f32) Color {
     return cdef.ColorBrightness(color, factor);
 }
 
-/// Get color with contrast correction, contrast values between -1.0f and 1.0f
 pub fn colorContrast(color: Color, contrast: f32) Color {
     return cdef.ColorContrast(color, contrast);
 }
 
-/// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn colorAlpha(color: Color, alpha: f32) Color {
     return cdef.ColorAlpha(color, alpha);
 }
 
-/// Get src alpha-blended into dst color with tint
 pub fn colorAlphaBlend(dst: Color, src: Color, tint: Color) Color {
     return cdef.ColorAlphaBlend(dst, src, tint);
 }
 
-/// Get Color structure from hexadecimal value
 pub fn getColor(hexValue: u32) Color {
     return cdef.GetColor(@as(c_uint, hexValue));
 }
 
-/// Get Color from a source pixel pointer of certain format
 pub fn getPixelColor(srcPtr: *anyopaque, format: PixelFormat) Color {
     return cdef.GetPixelColor(srcPtr, format);
 }
 
-/// Set color formatted into destination pixel pointer
 pub fn setPixelColor(dstPtr: *anyopaque, color: Color, format: PixelFormat) void {
     cdef.SetPixelColor(dstPtr, color, format);
 }
 
-/// Get pixel data size in bytes for certain format
 pub fn getPixelDataSize(width: i32, height: i32, format: PixelFormat) i32 {
     return @as(i32, cdef.GetPixelDataSize(@as(c_int, width), @as(c_int, height), format));
 }
 
-/// Get the default Font
 pub fn getFontDefault() Font {
     return cdef.GetFontDefault();
 }
 
-/// Load font from file into GPU memory (VRAM)
 pub fn loadFont(fileName: [:0]const u8) Font {
     return cdef.LoadFont(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load font from Image (XNA style)
 pub fn loadFontFromImage(image: Image, key: Color, firstChar: i32) Font {
     return cdef.LoadFontFromImage(image, key, @as(c_int, firstChar));
 }
 
-/// Check if a font is ready
 pub fn isFontReady(font: Font) bool {
     return cdef.IsFontReady(font);
 }
 
-/// Unload font from GPU memory (VRAM)
 pub fn unloadFont(font: Font) void {
     cdef.UnloadFont(font);
 }
 
-/// Export font as code file, returns true on success
 pub fn exportFontAsCode(font: Font, fileName: [:0]const u8) bool {
     return cdef.ExportFontAsCode(font, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Draw current FPS
 pub fn drawFPS(posX: i32, posY: i32) void {
     cdef.DrawFPS(@as(c_int, posX), @as(c_int, posY));
 }
 
-/// Draw text (using default font)
 pub fn drawText(text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
     cdef.DrawText(@as([*c]const u8, @ptrCast(text)), @as(c_int, posX), @as(c_int, posY), @as(c_int, fontSize), color);
 }
 
-/// Draw text using font and additional parameters
 pub fn drawTextEx(font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.DrawTextEx(font, @as([*c]const u8, @ptrCast(text)), position, fontSize, spacing, tint);
 }
 
-/// Draw text using Font and pro parameters (rotation)
 pub fn drawTextPro(font: Font, text: [:0]const u8, position: Vector2, origin: Vector2, rotation: f32, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.DrawTextPro(font, @as([*c]const u8, @ptrCast(text)), position, origin, rotation, fontSize, spacing, tint);
 }
 
-/// Draw one character (codepoint)
 pub fn drawTextCodepoint(font: Font, codepoint: i32, position: Vector2, fontSize: f32, tint: Color) void {
     cdef.DrawTextCodepoint(font, @as(c_int, codepoint), position, fontSize, tint);
 }
 
-/// Set vertical line spacing when drawing with line-breaks
 pub fn setTextLineSpacing(spacing: i32) void {
     cdef.SetTextLineSpacing(@as(c_int, spacing));
 }
 
-/// Measure string width for default font
 pub fn measureText(text: [:0]const u8, fontSize: i32) i32 {
     return @as(i32, cdef.MeasureText(@as([*c]const u8, @ptrCast(text)), @as(c_int, fontSize)));
 }
 
-/// Measure string size for Font
 pub fn measureTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32) Vector2 {
     return cdef.MeasureTextEx(font, @as([*c]const u8, @ptrCast(text)), fontSize, spacing);
 }
 
-/// Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphIndex(font: Font, codepoint: i32) i32 {
     return @as(i32, cdef.GetGlyphIndex(font, @as(c_int, codepoint)));
 }
 
-/// Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphInfo(font: Font, codepoint: i32) GlyphInfo {
     return cdef.GetGlyphInfo(font, @as(c_int, codepoint));
 }
 
-/// Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphAtlasRec(font: Font, codepoint: i32) Rectangle {
     return cdef.GetGlyphAtlasRec(font, @as(c_int, codepoint));
 }
 
-/// Unload UTF-8 text encoded from codepoints array
 pub fn unloadUTF8(text: [:0]u8) void {
     cdef.UnloadUTF8(@as([*c]u8, @ptrCast(text)));
 }
 
-/// Unload codepoints data from memory
 pub fn unloadCodepoints(codepoints: []i32) void {
     cdef.UnloadCodepoints(@as([*c]c_int, @ptrCast(codepoints)));
 }
 
-/// Get total number of codepoints in a UTF-8 encoded string
 pub fn getCodepointCount(text: [:0]const u8) i32 {
     return @as(i32, cdef.GetCodepointCount(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepoint(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepoint(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
-/// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepointNext(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepointNext(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
-/// Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepointPrevious(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepointPrevious(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
-/// Encode one codepoint into UTF-8 byte array (array length returned as parameter)
 pub fn codepointToUTF8(codepoint: i32, utf8Size: *i32) [:0]const u8 {
     return std.mem.span(cdef.CodepointToUTF8(@as(c_int, codepoint), @as([*c]c_int, @ptrCast(utf8Size))));
 }
 
-/// Copy one string to another, returns bytes copied
 pub fn textCopy(dst: *u8, src: [:0]const u8) i32 {
     return @as(i32, cdef.TextCopy(@as([*c]u8, @ptrCast(dst)), @as([*c]const u8, @ptrCast(src))));
 }
 
-/// Check if two text string are equal
 pub fn textIsEqual(text1: [:0]const u8, text2: [:0]const u8) bool {
     return cdef.TextIsEqual(@as([*c]const u8, @ptrCast(text1)), @as([*c]const u8, @ptrCast(text2)));
 }
 
-/// Get text length, checks for '\0' ending
 pub fn textLength(text: [:0]const u8) u32 {
     return @as(u32, cdef.TextLength(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get a piece of a text string
 pub fn textSubtext(text: [:0]const u8, position: i32, length: i32) [:0]const u8 {
     return std.mem.span(cdef.TextSubtext(@as([*c]const u8, @ptrCast(text)), @as(c_int, position), @as(c_int, length)));
 }
 
-/// Replace text string (WARNING: memory must be freed!)
 pub fn textReplace(text: [:0]const u8, replace: [:0]const u8, by: [:0]const u8) [:0]u8 {
     return std.mem.span(cdef.TextReplace(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(replace)), @as([*c]const u8, @ptrCast(by))));
 }
 
-/// Insert text in a position (WARNING: memory must be freed!)
 pub fn textInsert(text: [:0]const u8, insert: [:0]const u8, position: i32) [:0]u8 {
     return std.mem.span(cdef.TextInsert(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(insert)), @as(c_int, position)));
 }
 
-/// Append text at specific position and move cursor!
 pub fn textAppend(text: [:0]u8, append: [:0]const u8, position: *i32) void {
     cdef.TextAppend(@as([*c]u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(append)), @as([*c]c_int, @ptrCast(position)));
 }
 
-/// Find first text occurrence within a string
 pub fn textFindIndex(text: [:0]const u8, find: [:0]const u8) i32 {
     return @as(i32, cdef.TextFindIndex(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(find))));
 }
 
-/// Get upper case version of provided string
 pub fn textToUpper(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToUpper(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get lower case version of provided string
 pub fn textToLower(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToLower(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get Pascal case notation version of provided string
 pub fn textToPascal(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToPascal(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get Snake case notation version of provided string
 pub fn textToSnake(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToSnake(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get Camel case notation version of provided string
 pub fn textToCamel(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToCamel(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get integer value from text (negative values not supported)
 pub fn textToInteger(text: [:0]const u8) i32 {
     return @as(i32, cdef.TextToInteger(@as([*c]const u8, @ptrCast(text))));
 }
 
-/// Get float value from text (negative values not supported)
 pub fn textToFloat(text: [:0]const u8) f32 {
     return cdef.TextToFloat(@as([*c]const u8, @ptrCast(text)));
 }
 
-/// Draw a line in 3D world space
 pub fn drawLine3D(startPos: Vector3, endPos: Vector3, color: Color) void {
     cdef.DrawLine3D(startPos, endPos, color);
 }
 
-/// Draw a point in 3D space, actually a small line
 pub fn drawPoint3D(position: Vector3, color: Color) void {
     cdef.DrawPoint3D(position, color);
 }
 
-/// Draw a circle in 3D world space
 pub fn drawCircle3D(center: Vector3, radius: f32, rotationAxis: Vector3, rotationAngle: f32, color: Color) void {
     cdef.DrawCircle3D(center, radius, rotationAxis, rotationAngle, color);
 }
 
-/// Draw a color-filled triangle (vertex in counter-clockwise order!)
 pub fn drawTriangle3D(v1: Vector3, v2: Vector3, v3: Vector3, color: Color) void {
     cdef.DrawTriangle3D(v1, v2, v3, color);
 }
 
-/// Draw cube
 pub fn drawCube(position: Vector3, width: f32, height: f32, length: f32, color: Color) void {
     cdef.DrawCube(position, width, height, length, color);
 }
 
-/// Draw cube (Vector version)
 pub fn drawCubeV(position: Vector3, size: Vector3, color: Color) void {
     cdef.DrawCubeV(position, size, color);
 }
 
-/// Draw cube wires
 pub fn drawCubeWires(position: Vector3, width: f32, height: f32, length: f32, color: Color) void {
     cdef.DrawCubeWires(position, width, height, length, color);
 }
 
-/// Draw cube wires (Vector version)
 pub fn drawCubeWiresV(position: Vector3, size: Vector3, color: Color) void {
     cdef.DrawCubeWiresV(position, size, color);
 }
 
-/// Draw sphere
 pub fn drawSphere(centerPos: Vector3, radius: f32, color: Color) void {
     cdef.DrawSphere(centerPos, radius, color);
 }
 
-/// Draw sphere with extended parameters
 pub fn drawSphereEx(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) void {
     cdef.DrawSphereEx(centerPos, radius, @as(c_int, rings), @as(c_int, slices), color);
 }
 
-/// Draw sphere wires
 pub fn drawSphereWires(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) void {
     cdef.DrawSphereWires(centerPos, radius, @as(c_int, rings), @as(c_int, slices), color);
 }
 
-/// Draw a cylinder/cone
 pub fn drawCylinder(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) void {
     cdef.DrawCylinder(position, radiusTop, radiusBottom, height, @as(c_int, slices), color);
 }
 
-/// Draw a cylinder with base at startPos and top at endPos
 pub fn drawCylinderEx(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) void {
     cdef.DrawCylinderEx(startPos, endPos, startRadius, endRadius, @as(c_int, sides), color);
 }
 
-/// Draw a cylinder/cone wires
 pub fn drawCylinderWires(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) void {
     cdef.DrawCylinderWires(position, radiusTop, radiusBottom, height, @as(c_int, slices), color);
 }
 
-/// Draw a cylinder wires with base at startPos and top at endPos
 pub fn drawCylinderWiresEx(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) void {
     cdef.DrawCylinderWiresEx(startPos, endPos, startRadius, endRadius, @as(c_int, sides), color);
 }
 
-/// Draw a capsule with the center of its sphere caps at startPos and endPos
 pub fn drawCapsule(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) void {
     cdef.DrawCapsule(startPos, endPos, radius, @as(c_int, slices), @as(c_int, rings), color);
 }
 
-/// Draw capsule wireframe with the center of its sphere caps at startPos and endPos
 pub fn drawCapsuleWires(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) void {
     cdef.DrawCapsuleWires(startPos, endPos, radius, @as(c_int, slices), @as(c_int, rings), color);
 }
 
-/// Draw a plane XZ
 pub fn drawPlane(centerPos: Vector3, size: Vector2, color: Color) void {
     cdef.DrawPlane(centerPos, size, color);
 }
 
-/// Draw a ray line
 pub fn drawRay(ray: Ray, color: Color) void {
     cdef.DrawRay(ray, color);
 }
 
-/// Draw a grid (centered at (0, 0, 0))
 pub fn drawGrid(slices: i32, spacing: f32) void {
     cdef.DrawGrid(@as(c_int, slices), spacing);
 }
 
-/// Load model from files (meshes and materials)
 pub fn loadModel(fileName: [:0]const u8) Model {
     return cdef.LoadModel(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load model from generated mesh (default material)
 pub fn loadModelFromMesh(mesh: Mesh) Model {
     return cdef.LoadModelFromMesh(mesh);
 }
 
-/// Check if a model is ready
 pub fn isModelReady(model: Model) bool {
     return cdef.IsModelReady(model);
 }
 
-/// Unload model (including meshes) from memory (RAM and/or VRAM)
 pub fn unloadModel(model: Model) void {
     cdef.UnloadModel(model);
 }
 
-/// Compute model bounding box limits (considers all meshes)
 pub fn getModelBoundingBox(model: Model) BoundingBox {
     return cdef.GetModelBoundingBox(model);
 }
 
-/// Draw a model (with texture if set)
 pub fn drawModel(model: Model, position: Vector3, scale: f32, tint: Color) void {
     cdef.DrawModel(model, position, scale, tint);
 }
 
-/// Draw a model with extended parameters
 pub fn drawModelEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
     cdef.DrawModelEx(model, position, rotationAxis, rotationAngle, scale, tint);
 }
 
-/// Draw a model wires (with texture if set)
 pub fn drawModelWires(model: Model, position: Vector3, scale: f32, tint: Color) void {
     cdef.DrawModelWires(model, position, scale, tint);
 }
 
-/// Draw a model wires (with texture if set) with extended parameters
 pub fn drawModelWiresEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
     cdef.DrawModelWiresEx(model, position, rotationAxis, rotationAngle, scale, tint);
 }
 
-/// Draw bounding box (wires)
 pub fn drawBoundingBox(box: BoundingBox, color: Color) void {
     cdef.DrawBoundingBox(box, color);
 }
 
-/// Draw a billboard texture
 pub fn drawBillboard(camera: Camera, texture: Texture2D, position: Vector3, size: f32, tint: Color) void {
     cdef.DrawBillboard(camera, texture, position, size, tint);
 }
 
-/// Draw a billboard texture defined by source
 pub fn drawBillboardRec(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, size: Vector2, tint: Color) void {
     cdef.DrawBillboardRec(camera, texture, source, position, size, tint);
 }
 
-/// Draw a billboard texture defined by source and rotation
 pub fn drawBillboardPro(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawBillboardPro(camera, texture, source, position, up, size, origin, rotation, tint);
 }
 
-/// Upload mesh vertex data in GPU and provide VAO/VBO ids
 pub fn uploadMesh(mesh: *Mesh, dynamic: bool) void {
     cdef.UploadMesh(@as([*c]Mesh, @ptrCast(mesh)), dynamic);
 }
 
-/// Update mesh vertex data in GPU for a specific buffer index
 pub fn updateMeshBuffer(mesh: Mesh, index: i32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.UpdateMeshBuffer(mesh, @as(c_int, index), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
-/// Unload mesh data from CPU and GPU
 pub fn unloadMesh(mesh: Mesh) void {
     cdef.UnloadMesh(mesh);
 }
 
-/// Draw a 3d mesh with material and transform
 pub fn drawMesh(mesh: Mesh, material: Material, transform: Matrix) void {
     cdef.DrawMesh(mesh, material, transform);
 }
 
-/// Compute mesh bounding box limits
 pub fn getMeshBoundingBox(mesh: Mesh) BoundingBox {
     return cdef.GetMeshBoundingBox(mesh);
 }
 
-/// Compute mesh tangents
 pub fn genMeshTangents(mesh: *Mesh) void {
     cdef.GenMeshTangents(@as([*c]Mesh, @ptrCast(mesh)));
 }
 
-/// Export mesh data to file, returns true on success
 pub fn exportMesh(mesh: Mesh, fileName: [:0]const u8) bool {
     return cdef.ExportMesh(mesh, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Export mesh as code file (.h) defining multiple arrays of vertex attributes
 pub fn exportMeshAsCode(mesh: Mesh, fileName: [:0]const u8) bool {
     return cdef.ExportMeshAsCode(mesh, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Generate polygonal mesh
 pub fn genMeshPoly(sides: i32, radius: f32) Mesh {
     return cdef.GenMeshPoly(@as(c_int, sides), radius);
 }
 
-/// Generate plane mesh (with subdivisions)
 pub fn genMeshPlane(width: f32, length: f32, resX: i32, resZ: i32) Mesh {
     return cdef.GenMeshPlane(width, length, @as(c_int, resX), @as(c_int, resZ));
 }
 
-/// Generate cuboid mesh
 pub fn genMeshCube(width: f32, height: f32, length: f32) Mesh {
     return cdef.GenMeshCube(width, height, length);
 }
 
-/// Generate sphere mesh (standard sphere)
 pub fn genMeshSphere(radius: f32, rings: i32, slices: i32) Mesh {
     return cdef.GenMeshSphere(radius, @as(c_int, rings), @as(c_int, slices));
 }
 
-/// Generate half-sphere mesh (no bottom cap)
 pub fn genMeshHemiSphere(radius: f32, rings: i32, slices: i32) Mesh {
     return cdef.GenMeshHemiSphere(radius, @as(c_int, rings), @as(c_int, slices));
 }
 
-/// Generate cylinder mesh
 pub fn genMeshCylinder(radius: f32, height: f32, slices: i32) Mesh {
     return cdef.GenMeshCylinder(radius, height, @as(c_int, slices));
 }
 
-/// Generate cone/pyramid mesh
 pub fn genMeshCone(radius: f32, height: f32, slices: i32) Mesh {
     return cdef.GenMeshCone(radius, height, @as(c_int, slices));
 }
 
-/// Generate torus mesh
 pub fn genMeshTorus(radius: f32, size: f32, radSeg: i32, sides: i32) Mesh {
     return cdef.GenMeshTorus(radius, size, @as(c_int, radSeg), @as(c_int, sides));
 }
 
-/// Generate trefoil knot mesh
 pub fn genMeshKnot(radius: f32, size: f32, radSeg: i32, sides: i32) Mesh {
     return cdef.GenMeshKnot(radius, size, @as(c_int, radSeg), @as(c_int, sides));
 }
 
-/// Generate heightmap mesh from image data
 pub fn genMeshHeightmap(heightmap: Image, size: Vector3) Mesh {
     return cdef.GenMeshHeightmap(heightmap, size);
 }
 
-/// Generate cubes-based map mesh from image data
 pub fn genMeshCubicmap(cubicmap: Image, cubeSize: Vector3) Mesh {
     return cdef.GenMeshCubicmap(cubicmap, cubeSize);
 }
 
-/// Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
 pub fn loadMaterialDefault() Material {
     return cdef.LoadMaterialDefault();
 }
 
-/// Check if a material is ready
 pub fn isMaterialReady(material: Material) bool {
     return cdef.IsMaterialReady(material);
 }
 
-/// Unload material from GPU memory (VRAM)
 pub fn unloadMaterial(material: Material) void {
     cdef.UnloadMaterial(material);
 }
 
-/// Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
 pub fn setMaterialTexture(material: *Material, mapType: MaterialMapIndex, texture: Texture2D) void {
     cdef.SetMaterialTexture(@as([*c]Material, @ptrCast(material)), mapType, texture);
 }
 
-/// Set material for a mesh
 pub fn setModelMeshMaterial(model: *Model, meshId: i32, materialId: i32) void {
     cdef.SetModelMeshMaterial(@as([*c]Model, @ptrCast(model)), @as(c_int, meshId), @as(c_int, materialId));
 }
 
-/// Update model animation pose
 pub fn updateModelAnimation(model: Model, anim: ModelAnimation, frame: i32) void {
     cdef.UpdateModelAnimation(model, anim, @as(c_int, frame));
 }
 
-/// Unload animation data
 pub fn unloadModelAnimation(anim: ModelAnimation) void {
     cdef.UnloadModelAnimation(anim);
 }
 
-/// Check model animation skeleton match
 pub fn isModelAnimationValid(model: Model, anim: ModelAnimation) bool {
     return cdef.IsModelAnimationValid(model, anim);
 }
 
-/// Check collision between two spheres
 pub fn checkCollisionSpheres(center1: Vector3, radius1: f32, center2: Vector3, radius2: f32) bool {
     return cdef.CheckCollisionSpheres(center1, radius1, center2, radius2);
 }
 
-/// Check collision between two bounding boxes
 pub fn checkCollisionBoxes(box1: BoundingBox, box2: BoundingBox) bool {
     return cdef.CheckCollisionBoxes(box1, box2);
 }
 
-/// Check collision between box and sphere
 pub fn checkCollisionBoxSphere(box: BoundingBox, center: Vector3, radius: f32) bool {
     return cdef.CheckCollisionBoxSphere(box, center, radius);
 }
 
-/// Get collision info between ray and sphere
 pub fn getRayCollisionSphere(ray: Ray, center: Vector3, radius: f32) RayCollision {
     return cdef.GetRayCollisionSphere(ray, center, radius);
 }
 
-/// Get collision info between ray and box
 pub fn getRayCollisionBox(ray: Ray, box: BoundingBox) RayCollision {
     return cdef.GetRayCollisionBox(ray, box);
 }
 
-/// Get collision info between ray and mesh
 pub fn getRayCollisionMesh(ray: Ray, mesh: Mesh, transform: Matrix) RayCollision {
     return cdef.GetRayCollisionMesh(ray, mesh, transform);
 }
 
-/// Get collision info between ray and triangle
 pub fn getRayCollisionTriangle(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3) RayCollision {
     return cdef.GetRayCollisionTriangle(ray, p1, p2, p3);
 }
 
-/// Get collision info between ray and quad
 pub fn getRayCollisionQuad(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3, p4: Vector3) RayCollision {
     return cdef.GetRayCollisionQuad(ray, p1, p2, p3, p4);
 }
 
-/// Initialize audio device and context
 pub fn initAudioDevice() void {
     cdef.InitAudioDevice();
 }
 
-/// Close the audio device and context
 pub fn closeAudioDevice() void {
     cdef.CloseAudioDevice();
 }
 
-/// Check if audio device has been initialized successfully
 pub fn isAudioDeviceReady() bool {
     return cdef.IsAudioDeviceReady();
 }
 
-/// Set master volume (listener)
 pub fn setMasterVolume(volume: f32) void {
     cdef.SetMasterVolume(volume);
 }
 
-/// Get master volume (listener)
 pub fn getMasterVolume() f32 {
     return cdef.GetMasterVolume();
 }
 
-/// Load wave data from file
 pub fn loadWave(fileName: [:0]const u8) Wave {
     return cdef.LoadWave(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Checks if wave data is ready
 pub fn isWaveReady(wave: Wave) bool {
     return cdef.IsWaveReady(wave);
 }
 
-/// Load sound from file
 pub fn loadSound(fileName: [:0]const u8) Sound {
     return cdef.LoadSound(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Load sound from wave data
 pub fn loadSoundFromWave(wave: Wave) Sound {
     return cdef.LoadSoundFromWave(wave);
 }
 
-/// Create a new sound that shares the same sample data as the source sound, does not own the sound data
 pub fn loadSoundAlias(source: Sound) Sound {
     return cdef.LoadSoundAlias(source);
 }
 
-/// Checks if a sound is ready
 pub fn isSoundReady(sound: Sound) bool {
     return cdef.IsSoundReady(sound);
 }
 
-/// Update sound buffer with new data
 pub fn updateSound(sound: Sound, data: *const anyopaque, sampleCount: i32) void {
     cdef.UpdateSound(sound, data, @as(c_int, sampleCount));
 }
 
-/// Unload wave data
 pub fn unloadWave(wave: Wave) void {
     cdef.UnloadWave(wave);
 }
 
-/// Unload sound
 pub fn unloadSound(sound: Sound) void {
     cdef.UnloadSound(sound);
 }
 
-/// Unload a sound alias (does not deallocate sample data)
 pub fn unloadSoundAlias(alias: Sound) void {
     cdef.UnloadSoundAlias(alias);
 }
 
-/// Export wave data to file, returns true on success
 pub fn exportWave(wave: Wave, fileName: [:0]const u8) bool {
     return cdef.ExportWave(wave, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Export wave sample data to code (.h), returns true on success
 pub fn exportWaveAsCode(wave: Wave, fileName: [:0]const u8) bool {
     return cdef.ExportWaveAsCode(wave, @as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Play a sound
 pub fn playSound(sound: Sound) void {
     cdef.PlaySound(sound);
 }
 
-/// Stop playing a sound
 pub fn stopSound(sound: Sound) void {
     cdef.StopSound(sound);
 }
 
-/// Pause a sound
 pub fn pauseSound(sound: Sound) void {
     cdef.PauseSound(sound);
 }
 
-/// Resume a paused sound
 pub fn resumeSound(sound: Sound) void {
     cdef.ResumeSound(sound);
 }
 
-/// Check if a sound is currently playing
 pub fn isSoundPlaying(sound: Sound) bool {
     return cdef.IsSoundPlaying(sound);
 }
 
-/// Set volume for a sound (1.0 is max level)
 pub fn setSoundVolume(sound: Sound, volume: f32) void {
     cdef.SetSoundVolume(sound, volume);
 }
 
-/// Set pitch for a sound (1.0 is base level)
 pub fn setSoundPitch(sound: Sound, pitch: f32) void {
     cdef.SetSoundPitch(sound, pitch);
 }
 
-/// Set pan for a sound (0.5 is center)
 pub fn setSoundPan(sound: Sound, pan: f32) void {
     cdef.SetSoundPan(sound, pan);
 }
 
-/// Copy a wave to a new wave
 pub fn waveCopy(wave: Wave) Wave {
     return cdef.WaveCopy(wave);
 }
 
-/// Crop a wave to defined frames range
 pub fn waveCrop(wave: *Wave, initFrame: i32, finalFrame: i32) void {
     cdef.WaveCrop(@as([*c]Wave, @ptrCast(wave)), @as(c_int, initFrame), @as(c_int, finalFrame));
 }
 
-/// Convert wave data to desired format
 pub fn waveFormat(wave: *Wave, sampleRate: i32, sampleSize: i32, channels: i32) void {
     cdef.WaveFormat(@as([*c]Wave, @ptrCast(wave)), @as(c_int, sampleRate), @as(c_int, sampleSize), @as(c_int, channels));
 }
 
-/// Unload samples data loaded with LoadWaveSamples()
 pub fn unloadWaveSamples(samples: []f32) void {
     cdef.UnloadWaveSamples(@as([*c]f32, @ptrCast(samples)));
 }
 
-/// Load music stream from file
 pub fn loadMusicStream(fileName: [:0]const u8) Music {
     return cdef.LoadMusicStream(@as([*c]const u8, @ptrCast(fileName)));
 }
 
-/// Checks if a music stream is ready
 pub fn isMusicReady(music: Music) bool {
     return cdef.IsMusicReady(music);
 }
 
-/// Unload music stream
 pub fn unloadMusicStream(music: Music) void {
     cdef.UnloadMusicStream(music);
 }
 
-/// Start music playing
 pub fn playMusicStream(music: Music) void {
     cdef.PlayMusicStream(music);
 }
 
-/// Check if music is playing
 pub fn isMusicStreamPlaying(music: Music) bool {
     return cdef.IsMusicStreamPlaying(music);
 }
 
-/// Updates buffers for music streaming
 pub fn updateMusicStream(music: Music) void {
     cdef.UpdateMusicStream(music);
 }
 
-/// Stop music playing
 pub fn stopMusicStream(music: Music) void {
     cdef.StopMusicStream(music);
 }
 
-/// Pause music playing
 pub fn pauseMusicStream(music: Music) void {
     cdef.PauseMusicStream(music);
 }
 
-/// Resume playing paused music
 pub fn resumeMusicStream(music: Music) void {
     cdef.ResumeMusicStream(music);
 }
 
-/// Seek music to a position (in seconds)
 pub fn seekMusicStream(music: Music, position: f32) void {
     cdef.SeekMusicStream(music, position);
 }
 
-/// Set volume for music (1.0 is max level)
 pub fn setMusicVolume(music: Music, volume: f32) void {
     cdef.SetMusicVolume(music, volume);
 }
 
-/// Set pitch for a music (1.0 is base level)
 pub fn setMusicPitch(music: Music, pitch: f32) void {
     cdef.SetMusicPitch(music, pitch);
 }
 
-/// Set pan for a music (0.5 is center)
 pub fn setMusicPan(music: Music, pan: f32) void {
     cdef.SetMusicPan(music, pan);
 }
 
-/// Get music time length (in seconds)
 pub fn getMusicTimeLength(music: Music) f32 {
     return cdef.GetMusicTimeLength(music);
 }
 
-/// Get current music time played (in seconds)
 pub fn getMusicTimePlayed(music: Music) f32 {
     return cdef.GetMusicTimePlayed(music);
 }
 
-/// Load audio stream (to stream raw audio pcm data)
 pub fn loadAudioStream(sampleRate: u32, sampleSize: u32, channels: u32) AudioStream {
     return cdef.LoadAudioStream(@as(c_uint, sampleRate), @as(c_uint, sampleSize), @as(c_uint, channels));
 }
 
-/// Checks if an audio stream is ready
 pub fn isAudioStreamReady(stream: AudioStream) bool {
     return cdef.IsAudioStreamReady(stream);
 }
 
-/// Unload audio stream and free memory
 pub fn unloadAudioStream(stream: AudioStream) void {
     cdef.UnloadAudioStream(stream);
 }
 
-/// Update audio stream buffers with data
 pub fn updateAudioStream(stream: AudioStream, data: *const anyopaque, frameCount: i32) void {
     cdef.UpdateAudioStream(stream, data, @as(c_int, frameCount));
 }
 
-/// Check if any audio stream buffers requires refill
 pub fn isAudioStreamProcessed(stream: AudioStream) bool {
     return cdef.IsAudioStreamProcessed(stream);
 }
 
-/// Play audio stream
 pub fn playAudioStream(stream: AudioStream) void {
     cdef.PlayAudioStream(stream);
 }
 
-/// Pause audio stream
 pub fn pauseAudioStream(stream: AudioStream) void {
     cdef.PauseAudioStream(stream);
 }
 
-/// Resume audio stream
 pub fn resumeAudioStream(stream: AudioStream) void {
     cdef.ResumeAudioStream(stream);
 }
 
-/// Check if audio stream is playing
 pub fn isAudioStreamPlaying(stream: AudioStream) bool {
     return cdef.IsAudioStreamPlaying(stream);
 }
 
-/// Stop audio stream
 pub fn stopAudioStream(stream: AudioStream) void {
     cdef.StopAudioStream(stream);
 }
 
-/// Set volume for audio stream (1.0 is max level)
 pub fn setAudioStreamVolume(stream: AudioStream, volume: f32) void {
     cdef.SetAudioStreamVolume(stream, volume);
 }
 
-/// Set pitch for audio stream (1.0 is base level)
 pub fn setAudioStreamPitch(stream: AudioStream, pitch: f32) void {
     cdef.SetAudioStreamPitch(stream, pitch);
 }
 
-/// Set pan for audio stream (0.5 is centered)
 pub fn setAudioStreamPan(stream: AudioStream, pan: f32) void {
     cdef.SetAudioStreamPan(stream, pan);
 }
 
-/// Default size for new audio streams
 pub fn setAudioStreamBufferSizeDefault(size: i32) void {
     cdef.SetAudioStreamBufferSizeDefault(@as(c_int, size));
 }
 
-/// Audio thread callback to request new data
 pub fn setAudioStreamCallback(stream: AudioStream, callback: AudioCallback) void {
     cdef.SetAudioStreamCallback(stream, callback);
 }
 
-/// Attach audio stream processor to stream, receives the samples as 'float'
 pub fn attachAudioStreamProcessor(stream: AudioStream, processor: AudioCallback) void {
     cdef.AttachAudioStreamProcessor(stream, processor);
 }
 
-/// Detach audio stream processor from stream
 pub fn detachAudioStreamProcessor(stream: AudioStream, processor: AudioCallback) void {
     cdef.DetachAudioStreamProcessor(stream, processor);
 }
 
-/// Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 pub fn attachAudioMixedProcessor(processor: AudioCallback) void {
     cdef.AttachAudioMixedProcessor(processor);
 }
 
-/// Detach audio stream processor from the entire audio pipeline
 pub fn detachAudioMixedProcessor(processor: AudioCallback) void {
     cdef.DetachAudioMixedProcessor(processor);
 }

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -1993,2110 +1993,2637 @@ pub const mem = std.mem.Allocator{
     .vtable = &mem_vtable,
 };
 
+/// Initialize window and OpenGL context
 pub fn initWindow(width: i32, height: i32, title: [:0]const u8) void {
     cdef.InitWindow(@as(c_int, width), @as(c_int, height), @as([*c]const u8, @ptrCast(title)));
 }
 
+/// Close window and unload OpenGL context
 pub fn closeWindow() void {
     cdef.CloseWindow();
 }
 
+/// Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
 pub fn windowShouldClose() bool {
     return cdef.WindowShouldClose();
 }
 
+/// Check if window has been initialized successfully
 pub fn isWindowReady() bool {
     return cdef.IsWindowReady();
 }
 
+/// Check if window is currently fullscreen
 pub fn isWindowFullscreen() bool {
     return cdef.IsWindowFullscreen();
 }
 
+/// Check if window is currently hidden (only PLATFORM_DESKTOP)
 pub fn isWindowHidden() bool {
     return cdef.IsWindowHidden();
 }
 
+/// Check if window is currently minimized (only PLATFORM_DESKTOP)
 pub fn isWindowMinimized() bool {
     return cdef.IsWindowMinimized();
 }
 
+/// Check if window is currently maximized (only PLATFORM_DESKTOP)
 pub fn isWindowMaximized() bool {
     return cdef.IsWindowMaximized();
 }
 
+/// Check if window is currently focused (only PLATFORM_DESKTOP)
 pub fn isWindowFocused() bool {
     return cdef.IsWindowFocused();
 }
 
+/// Check if window has been resized last frame
 pub fn isWindowResized() bool {
     return cdef.IsWindowResized();
 }
 
+/// Check if one specific window flag is enabled
 pub fn isWindowState(flag: ConfigFlags) bool {
     return cdef.IsWindowState(flag);
 }
 
+/// Set window configuration state using flags (only PLATFORM_DESKTOP)
 pub fn setWindowState(flags: ConfigFlags) void {
     cdef.SetWindowState(flags);
 }
 
+/// Clear window configuration state flags
 pub fn clearWindowState(flags: ConfigFlags) void {
     cdef.ClearWindowState(flags);
 }
 
+/// Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
 pub fn toggleFullscreen() void {
     cdef.ToggleFullscreen();
 }
 
+/// Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
 pub fn toggleBorderlessWindowed() void {
     cdef.ToggleBorderlessWindowed();
 }
 
+/// Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 pub fn maximizeWindow() void {
     cdef.MaximizeWindow();
 }
 
+/// Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
 pub fn minimizeWindow() void {
     cdef.MinimizeWindow();
 }
 
+/// Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
 pub fn restoreWindow() void {
     cdef.RestoreWindow();
 }
 
+/// Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
 pub fn setWindowIcon(image: Image) void {
     cdef.SetWindowIcon(image);
 }
 
+/// Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
 pub fn setWindowTitle(title: [:0]const u8) void {
     cdef.SetWindowTitle(@as([*c]const u8, @ptrCast(title)));
 }
 
+/// Set window position on screen (only PLATFORM_DESKTOP)
 pub fn setWindowPosition(x: i32, y: i32) void {
     cdef.SetWindowPosition(@as(c_int, x), @as(c_int, y));
 }
 
+/// Set monitor for the current window
 pub fn setWindowMonitor(monitor: i32) void {
     cdef.SetWindowMonitor(@as(c_int, monitor));
 }
 
+/// Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 pub fn setWindowMinSize(width: i32, height: i32) void {
     cdef.SetWindowMinSize(@as(c_int, width), @as(c_int, height));
 }
 
+/// Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
 pub fn setWindowMaxSize(width: i32, height: i32) void {
     cdef.SetWindowMaxSize(@as(c_int, width), @as(c_int, height));
 }
 
+/// Set window dimensions
 pub fn setWindowSize(width: i32, height: i32) void {
     cdef.SetWindowSize(@as(c_int, width), @as(c_int, height));
 }
 
+/// Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
 pub fn setWindowOpacity(opacity: f32) void {
     cdef.SetWindowOpacity(opacity);
 }
 
+/// Set window focused (only PLATFORM_DESKTOP)
 pub fn setWindowFocused() void {
     cdef.SetWindowFocused();
 }
 
+/// Get native window handle
 pub fn getWindowHandle() *anyopaque {
     return cdef.GetWindowHandle();
 }
 
+/// Get current screen width
 pub fn getScreenWidth() i32 {
     return @as(i32, cdef.GetScreenWidth());
 }
 
+/// Get current screen height
 pub fn getScreenHeight() i32 {
     return @as(i32, cdef.GetScreenHeight());
 }
 
+/// Get current render width (it considers HiDPI)
 pub fn getRenderWidth() i32 {
     return @as(i32, cdef.GetRenderWidth());
 }
 
+/// Get current render height (it considers HiDPI)
 pub fn getRenderHeight() i32 {
     return @as(i32, cdef.GetRenderHeight());
 }
 
+/// Get number of connected monitors
 pub fn getMonitorCount() i32 {
     return @as(i32, cdef.GetMonitorCount());
 }
 
+/// Get current connected monitor
 pub fn getCurrentMonitor() i32 {
     return @as(i32, cdef.GetCurrentMonitor());
 }
 
+/// Get specified monitor position
 pub fn getMonitorPosition(monitor: i32) Vector2 {
     return cdef.GetMonitorPosition(@as(c_int, monitor));
 }
 
+/// Get specified monitor width (current video mode used by monitor)
 pub fn getMonitorWidth(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorWidth(@as(c_int, monitor)));
 }
 
+/// Get specified monitor height (current video mode used by monitor)
 pub fn getMonitorHeight(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorHeight(@as(c_int, monitor)));
 }
 
+/// Get specified monitor physical width in millimetres
 pub fn getMonitorPhysicalWidth(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorPhysicalWidth(@as(c_int, monitor)));
 }
 
+/// Get specified monitor physical height in millimetres
 pub fn getMonitorPhysicalHeight(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorPhysicalHeight(@as(c_int, monitor)));
 }
 
+/// Get specified monitor refresh rate
 pub fn getMonitorRefreshRate(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorRefreshRate(@as(c_int, monitor)));
 }
 
+/// Get window position XY on monitor
 pub fn getWindowPosition() Vector2 {
     return cdef.GetWindowPosition();
 }
 
+/// Get window scale DPI factor
 pub fn getWindowScaleDPI() Vector2 {
     return cdef.GetWindowScaleDPI();
 }
 
+/// Get the human-readable, UTF-8 encoded name of the specified monitor
 pub fn getMonitorName(monitor: i32) [:0]const u8 {
     return std.mem.span(cdef.GetMonitorName(@as(c_int, monitor)));
 }
 
+/// Set clipboard text content
 pub fn setClipboardText(text: [:0]const u8) void {
     cdef.SetClipboardText(@as([*c]const u8, @ptrCast(text)));
 }
 
+/// Get clipboard text content
 pub fn getClipboardText() [:0]const u8 {
     return std.mem.span(cdef.GetClipboardText());
 }
 
+/// Enable waiting for events on EndDrawing(), no automatic event polling
 pub fn enableEventWaiting() void {
     cdef.EnableEventWaiting();
 }
 
+/// Disable waiting for events on EndDrawing(), automatic events polling
 pub fn disableEventWaiting() void {
     cdef.DisableEventWaiting();
 }
 
+/// Shows cursor
 pub fn showCursor() void {
     cdef.ShowCursor();
 }
 
+/// Hides cursor
 pub fn hideCursor() void {
     cdef.HideCursor();
 }
 
+/// Check if cursor is not visible
 pub fn isCursorHidden() bool {
     return cdef.IsCursorHidden();
 }
 
+/// Enables cursor (unlock cursor)
 pub fn enableCursor() void {
     cdef.EnableCursor();
 }
 
+/// Disables cursor (lock cursor)
 pub fn disableCursor() void {
     cdef.DisableCursor();
 }
 
+/// Check if cursor is on the screen
 pub fn isCursorOnScreen() bool {
     return cdef.IsCursorOnScreen();
 }
 
+/// Set background color (framebuffer clear color)
 pub fn clearBackground(color: Color) void {
     cdef.ClearBackground(color);
 }
 
+/// Setup canvas (framebuffer) to start drawing
 pub fn beginDrawing() void {
     cdef.BeginDrawing();
 }
 
+/// End canvas drawing and swap buffers (double buffering)
 pub fn endDrawing() void {
     cdef.EndDrawing();
 }
 
+/// Begin 2D mode with custom camera (2D)
 pub fn beginMode2D(camera: Camera2D) void {
     cdef.BeginMode2D(camera);
 }
 
+/// Ends 2D mode with custom camera
 pub fn endMode2D() void {
     cdef.EndMode2D();
 }
 
+/// Begin 3D mode with custom camera (3D)
 pub fn beginMode3D(camera: Camera3D) void {
     cdef.BeginMode3D(camera);
 }
 
+/// Ends 3D mode and returns to default 2D orthographic mode
 pub fn endMode3D() void {
     cdef.EndMode3D();
 }
 
+/// Begin drawing to render texture
 pub fn beginTextureMode(target: RenderTexture2D) void {
     cdef.BeginTextureMode(target);
 }
 
+/// Ends drawing to render texture
 pub fn endTextureMode() void {
     cdef.EndTextureMode();
 }
 
+/// Begin custom shader drawing
 pub fn beginShaderMode(shader: Shader) void {
     cdef.BeginShaderMode(shader);
 }
 
+/// End custom shader drawing (use default shader)
 pub fn endShaderMode() void {
     cdef.EndShaderMode();
 }
 
+/// Begin blending mode (alpha, additive, multiplied, subtract, custom)
 pub fn beginBlendMode(mode: BlendMode) void {
     cdef.BeginBlendMode(mode);
 }
 
+/// End blending mode (reset to default: alpha blending)
 pub fn endBlendMode() void {
     cdef.EndBlendMode();
 }
 
+/// Begin scissor mode (define screen area for following drawing)
 pub fn beginScissorMode(x: i32, y: i32, width: i32, height: i32) void {
     cdef.BeginScissorMode(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
+/// End scissor mode
 pub fn endScissorMode() void {
     cdef.EndScissorMode();
 }
 
+/// Begin stereo rendering (requires VR simulator)
 pub fn beginVrStereoMode(config: VrStereoConfig) void {
     cdef.BeginVrStereoMode(config);
 }
 
+/// End stereo rendering (requires VR simulator)
 pub fn endVrStereoMode() void {
     cdef.EndVrStereoMode();
 }
 
+/// Load VR stereo config for VR simulator device parameters
 pub fn loadVrStereoConfig(device: VrDeviceInfo) VrStereoConfig {
     return cdef.LoadVrStereoConfig(device);
 }
 
+/// Unload VR stereo config
 pub fn unloadVrStereoConfig(config: VrStereoConfig) void {
     cdef.UnloadVrStereoConfig(config);
 }
 
+/// Check if a shader is ready
 pub fn isShaderReady(shader: Shader) bool {
     return cdef.IsShaderReady(shader);
 }
 
+/// Get shader uniform location
 pub fn getShaderLocation(shader: Shader, uniformName: [:0]const u8) i32 {
     return @as(i32, cdef.GetShaderLocation(shader, @as([*c]const u8, @ptrCast(uniformName))));
 }
 
+/// Get shader attribute location
 pub fn getShaderLocationAttrib(shader: Shader, attribName: [:0]const u8) i32 {
     return @as(i32, cdef.GetShaderLocationAttrib(shader, @as([*c]const u8, @ptrCast(attribName))));
 }
 
+/// Set shader uniform value
 pub fn setShaderValue(shader: Shader, locIndex: i32, value: *const anyopaque, uniformType: ShaderUniformDataType) void {
     cdef.SetShaderValue(shader, @as(c_int, locIndex), value, uniformType);
 }
 
+/// Set shader uniform value vector
 pub fn setShaderValueV(shader: Shader, locIndex: i32, value: *const anyopaque, uniformType: ShaderUniformDataType, count: i32) void {
     cdef.SetShaderValueV(shader, @as(c_int, locIndex), value, uniformType, @as(c_int, count));
 }
 
+/// Set shader uniform value (matrix 4x4)
 pub fn setShaderValueMatrix(shader: Shader, locIndex: i32, mat: Matrix) void {
     cdef.SetShaderValueMatrix(shader, @as(c_int, locIndex), mat);
 }
 
+/// Set shader uniform value for texture (sampler2d)
 pub fn setShaderValueTexture(shader: Shader, locIndex: i32, texture: Texture2D) void {
     cdef.SetShaderValueTexture(shader, @as(c_int, locIndex), texture);
 }
 
+/// Unload shader from GPU memory (VRAM)
 pub fn unloadShader(shader: Shader) void {
     cdef.UnloadShader(shader);
 }
 
+/// Get a ray trace from screen position (i.e mouse)
 pub fn getScreenToWorldRay(position: Vector2, camera: Camera) Ray {
     return cdef.GetScreenToWorldRay(position, camera);
 }
 
+/// Get a ray trace from screen position (i.e mouse) in a viewport
 pub fn getScreenToWorldRayEx(position: Vector2, camera: Camera, width: i32, height: i32) Ray {
     return cdef.GetScreenToWorldRayEx(position, camera, @as(c_int, width), @as(c_int, height));
 }
 
+/// Get the screen space position for a 3d world space position
 pub fn getWorldToScreen(position: Vector3, camera: Camera) Vector2 {
     return cdef.GetWorldToScreen(position, camera);
 }
 
+/// Get size position for a 3d world space position
 pub fn getWorldToScreenEx(position: Vector3, camera: Camera, width: i32, height: i32) Vector2 {
     return cdef.GetWorldToScreenEx(position, camera, @as(c_int, width), @as(c_int, height));
 }
 
+/// Get the screen space position for a 2d camera world space position
 pub fn getWorldToScreen2D(position: Vector2, camera: Camera2D) Vector2 {
     return cdef.GetWorldToScreen2D(position, camera);
 }
 
+/// Get the world space position for a 2d camera screen space position
 pub fn getScreenToWorld2D(position: Vector2, camera: Camera2D) Vector2 {
     return cdef.GetScreenToWorld2D(position, camera);
 }
 
+/// Get camera transform matrix (view matrix)
 pub fn getCameraMatrix(camera: Camera) Matrix {
     return cdef.GetCameraMatrix(camera);
 }
 
+/// Get camera 2d transform matrix
 pub fn getCameraMatrix2D(camera: Camera2D) Matrix {
     return cdef.GetCameraMatrix2D(camera);
 }
 
+/// Set target FPS (maximum)
 pub fn setTargetFPS(fps: i32) void {
     cdef.SetTargetFPS(@as(c_int, fps));
 }
 
+/// Get time in seconds for last frame drawn (delta time)
 pub fn getFrameTime() f32 {
     return cdef.GetFrameTime();
 }
 
+/// Get elapsed time in seconds since InitWindow()
 pub fn getTime() f64 {
     return cdef.GetTime();
 }
 
+/// Get current FPS
 pub fn getFPS() i32 {
     return @as(i32, cdef.GetFPS());
 }
 
+/// Swap back buffer with front buffer (screen drawing)
 pub fn swapScreenBuffer() void {
     cdef.SwapScreenBuffer();
 }
 
+/// Register all input events
 pub fn pollInputEvents() void {
     cdef.PollInputEvents();
 }
 
+/// Wait for some time (halt program execution)
 pub fn waitTime(seconds: f64) void {
     cdef.WaitTime(seconds);
 }
 
+/// Set the seed for the random number generator
 pub fn setRandomSeed(seed: u32) void {
     cdef.SetRandomSeed(@as(c_uint, seed));
 }
 
+/// Get a random value between min and max (both included)
 pub fn getRandomValue(min: i32, max: i32) i32 {
     return @as(i32, cdef.GetRandomValue(@as(c_int, min), @as(c_int, max)));
 }
 
+/// Unload random values sequence
 pub fn unloadRandomSequence(sequence: []i32) void {
     cdef.UnloadRandomSequence(@as([*c]c_int, @ptrCast(sequence)));
 }
 
+/// Takes a screenshot of current screen (filename extension defines format)
 pub fn takeScreenshot(fileName: [:0]const u8) void {
     cdef.TakeScreenshot(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Setup init configuration flags (view FLAGS)
 pub fn setConfigFlags(flags: ConfigFlags) void {
     cdef.SetConfigFlags(flags);
 }
 
+/// Open URL with default system browser (if available)
 pub fn openURL(url: [:0]const u8) void {
     cdef.OpenURL(@as([*c]const u8, @ptrCast(url)));
 }
 
+/// Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 pub fn traceLog(logLevel: TraceLogLevel, text: [:0]const u8) void {
     cdef.TraceLog(logLevel, @as([*c]const u8, @ptrCast(text)));
 }
 
+/// Set the current threshold (minimum) log level
 pub fn setTraceLogLevel(logLevel: TraceLogLevel) void {
     cdef.SetTraceLogLevel(logLevel);
 }
 
+/// Internal memory allocator
 pub fn memAlloc(size: u32) *anyopaque {
     return cdef.MemAlloc(@as(c_uint, size));
 }
 
+/// Internal memory reallocator
 pub fn memRealloc(ptr: *anyopaque, size: u32) *anyopaque {
     return cdef.MemRealloc(ptr, @as(c_uint, size));
 }
 
+/// Internal memory free
 pub fn memFree(ptr: *anyopaque) void {
     cdef.MemFree(ptr);
 }
 
+/// Set custom file binary data loader
 pub fn setLoadFileDataCallback(callback: LoadFileDataCallback) void {
     cdef.SetLoadFileDataCallback(callback);
 }
 
+/// Set custom file binary data saver
 pub fn setSaveFileDataCallback(callback: SaveFileDataCallback) void {
     cdef.SetSaveFileDataCallback(callback);
 }
 
+/// Set custom file text data loader
 pub fn setLoadFileTextCallback(callback: LoadFileTextCallback) void {
     cdef.SetLoadFileTextCallback(callback);
 }
 
+/// Set custom file text data saver
 pub fn setSaveFileTextCallback(callback: SaveFileTextCallback) void {
     cdef.SetSaveFileTextCallback(callback);
 }
 
+/// Unload file data allocated by LoadFileData()
 pub fn unloadFileData(data: []u8) void {
     cdef.UnloadFileData(@as([*c]u8, @ptrCast(data)));
 }
 
+/// Load text data from file (read), returns a '\0' terminated string
 pub fn loadFileText(fileName: [:0]const u8) [:0]u8 {
     return std.mem.span(cdef.LoadFileText(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Unload file text data allocated by LoadFileText()
 pub fn unloadFileText(text: [:0]u8) void {
     cdef.UnloadFileText(@as([*c]u8, @ptrCast(text)));
 }
 
+/// Save text data to file (write), string must be '\0' terminated, returns true on success
 pub fn saveFileText(fileName: [:0]const u8, text: [:0]u8) bool {
     return cdef.SaveFileText(@as([*c]const u8, @ptrCast(fileName)), @as([*c]u8, @ptrCast(text)));
 }
 
+/// Check if file exists
 pub fn fileExists(fileName: [:0]const u8) bool {
     return cdef.FileExists(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Check if a directory path exists
 pub fn directoryExists(dirPath: [:0]const u8) bool {
     return cdef.DirectoryExists(@as([*c]const u8, @ptrCast(dirPath)));
 }
 
+/// Check file extension (including point: .png, .wav)
 pub fn isFileExtension(fileName: [:0]const u8, ext: [:0]const u8) bool {
     return cdef.IsFileExtension(@as([*c]const u8, @ptrCast(fileName)), @as([*c]const u8, @ptrCast(ext)));
 }
 
+/// Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
 pub fn getFileLength(fileName: [:0]const u8) i32 {
     return @as(i32, cdef.GetFileLength(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Get pointer to extension for a filename string (includes dot: '.png')
 pub fn getFileExtension(fileName: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileExtension(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Get pointer to filename for a path string
 pub fn getFileName(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileName(@as([*c]const u8, @ptrCast(filePath))));
 }
 
+/// Get filename string without extension (uses static string)
 pub fn getFileNameWithoutExt(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileNameWithoutExt(@as([*c]const u8, @ptrCast(filePath))));
 }
 
+/// Get full path for a given fileName with path (uses static string)
 pub fn getDirectoryPath(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetDirectoryPath(@as([*c]const u8, @ptrCast(filePath))));
 }
 
+/// Get previous directory path for a given path (uses static string)
 pub fn getPrevDirectoryPath(dirPath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetPrevDirectoryPath(@as([*c]const u8, @ptrCast(dirPath))));
 }
 
+/// Get current working directory (uses static string)
 pub fn getWorkingDirectory() [:0]const u8 {
     return std.mem.span(cdef.GetWorkingDirectory());
 }
 
+/// Get the directory of the running application (uses static string)
 pub fn getApplicationDirectory() [:0]const u8 {
     return std.mem.span(cdef.GetApplicationDirectory());
 }
 
+/// Change working directory, return true on success
 pub fn changeDirectory(dir: [:0]const u8) bool {
     return cdef.ChangeDirectory(@as([*c]const u8, @ptrCast(dir)));
 }
 
+/// Check if a given path is a file or a directory
 pub fn isPathFile(path: [:0]const u8) bool {
     return cdef.IsPathFile(@as([*c]const u8, @ptrCast(path)));
 }
 
+/// Check if fileName is valid for the platform/OS
 pub fn isFileNameValid(fileName: [:0]const u8) bool {
     return cdef.IsFileNameValid(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load directory filepaths
 pub fn loadDirectoryFiles(dirPath: [:0]const u8) FilePathList {
     return cdef.LoadDirectoryFiles(@as([*c]const u8, @ptrCast(dirPath)));
 }
 
+/// Load directory filepaths with extension filtering and recursive directory scan
 pub fn loadDirectoryFilesEx(basePath: [:0]const u8, filter: [:0]const u8, scanSubdirs: bool) FilePathList {
     return cdef.LoadDirectoryFilesEx(@as([*c]const u8, @ptrCast(basePath)), @as([*c]const u8, @ptrCast(filter)), scanSubdirs);
 }
 
+/// Unload filepaths
 pub fn unloadDirectoryFiles(files: FilePathList) void {
     cdef.UnloadDirectoryFiles(files);
 }
 
+/// Check if a file has been dropped into window
 pub fn isFileDropped() bool {
     return cdef.IsFileDropped();
 }
 
+/// Load dropped filepaths
 pub fn loadDroppedFiles() FilePathList {
     return cdef.LoadDroppedFiles();
 }
 
+/// Unload dropped filepaths
 pub fn unloadDroppedFiles(files: FilePathList) void {
     cdef.UnloadDroppedFiles(files);
 }
 
+/// Get file modification time (last write time)
 pub fn getFileModTime(fileName: [:0]const u8) i64 {
     return @as(i64, cdef.GetFileModTime(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
 pub fn loadAutomationEventList(fileName: [:0]const u8) AutomationEventList {
     return cdef.LoadAutomationEventList(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Unload automation events list from file
 pub fn unloadAutomationEventList(list: AutomationEventList) void {
     cdef.UnloadAutomationEventList(list);
 }
 
+/// Export automation events list as text file
 pub fn exportAutomationEventList(list: AutomationEventList, fileName: [:0]const u8) bool {
     return cdef.ExportAutomationEventList(list, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Set automation event list to record to
 pub fn setAutomationEventList(list: *AutomationEventList) void {
     cdef.SetAutomationEventList(@as([*c]AutomationEventList, @ptrCast(list)));
 }
 
+/// Set automation event internal base frame to start recording
 pub fn setAutomationEventBaseFrame(frame: i32) void {
     cdef.SetAutomationEventBaseFrame(@as(c_int, frame));
 }
 
+/// Start recording automation events (AutomationEventList must be set)
 pub fn startAutomationEventRecording() void {
     cdef.StartAutomationEventRecording();
 }
 
+/// Stop recording automation events
 pub fn stopAutomationEventRecording() void {
     cdef.StopAutomationEventRecording();
 }
 
+/// Play a recorded automation event
 pub fn playAutomationEvent(event: AutomationEvent) void {
     cdef.PlayAutomationEvent(event);
 }
 
+/// Check if a key has been pressed once
 pub fn isKeyPressed(key: KeyboardKey) bool {
     return cdef.IsKeyPressed(key);
 }
 
+/// Check if a key has been pressed again (Only PLATFORM_DESKTOP)
 pub fn isKeyPressedRepeat(key: KeyboardKey) bool {
     return cdef.IsKeyPressedRepeat(key);
 }
 
+/// Check if a key is being pressed
 pub fn isKeyDown(key: KeyboardKey) bool {
     return cdef.IsKeyDown(key);
 }
 
+/// Check if a key has been released once
 pub fn isKeyReleased(key: KeyboardKey) bool {
     return cdef.IsKeyReleased(key);
 }
 
+/// Check if a key is NOT being pressed
 pub fn isKeyUp(key: KeyboardKey) bool {
     return cdef.IsKeyUp(key);
 }
 
+/// Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 pub fn getKeyPressed() KeyboardKey {
     return cdef.GetKeyPressed();
 }
 
+/// Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 pub fn getCharPressed() i32 {
     return @as(i32, cdef.GetCharPressed());
 }
 
+/// Set a custom key to exit program (default is ESC)
 pub fn setExitKey(key: KeyboardKey) void {
     cdef.SetExitKey(key);
 }
 
+/// Check if a gamepad is available
 pub fn isGamepadAvailable(gamepad: i32) bool {
     return cdef.IsGamepadAvailable(@as(c_int, gamepad));
 }
 
+/// Get gamepad internal name id
 pub fn getGamepadName(gamepad: i32) [:0]const u8 {
     return std.mem.span(cdef.GetGamepadName(@as(c_int, gamepad)));
 }
 
+/// Check if a gamepad button has been pressed once
 pub fn isGamepadButtonPressed(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonPressed(@as(c_int, gamepad), button);
 }
 
+/// Check if a gamepad button is being pressed
 pub fn isGamepadButtonDown(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonDown(@as(c_int, gamepad), button);
 }
 
+/// Check if a gamepad button has been released once
 pub fn isGamepadButtonReleased(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonReleased(@as(c_int, gamepad), button);
 }
 
+/// Check if a gamepad button is NOT being pressed
 pub fn isGamepadButtonUp(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonUp(@as(c_int, gamepad), button);
 }
 
+/// Get the last gamepad button pressed
 pub fn getGamepadButtonPressed() GamepadButton {
     return cdef.GetGamepadButtonPressed();
 }
 
+/// Get gamepad axis count for a gamepad
 pub fn getGamepadAxisCount(gamepad: i32) i32 {
     return @as(i32, cdef.GetGamepadAxisCount(@as(c_int, gamepad)));
 }
 
+/// Get axis movement value for a gamepad axis
 pub fn getGamepadAxisMovement(gamepad: i32, axis: i32) f32 {
     return cdef.GetGamepadAxisMovement(@as(c_int, gamepad), @as(c_int, axis));
 }
 
+/// Set internal gamepad mappings (SDL_GameControllerDB)
 pub fn setGamepadMappings(mappings: [:0]const u8) i32 {
     return @as(i32, cdef.SetGamepadMappings(@as([*c]const u8, @ptrCast(mappings))));
 }
 
+/// Set gamepad vibration for both motors
 pub fn setGamepadVibration(gamepad: i32, leftMotor: f32, rightMotor: f32) void {
     cdef.SetGamepadVibration(@as(c_int, gamepad), leftMotor, rightMotor);
 }
 
+/// Check if a mouse button has been pressed once
 pub fn isMouseButtonPressed(button: MouseButton) bool {
     return cdef.IsMouseButtonPressed(button);
 }
 
+/// Check if a mouse button is being pressed
 pub fn isMouseButtonDown(button: MouseButton) bool {
     return cdef.IsMouseButtonDown(button);
 }
 
+/// Check if a mouse button has been released once
 pub fn isMouseButtonReleased(button: MouseButton) bool {
     return cdef.IsMouseButtonReleased(button);
 }
 
+/// Check if a mouse button is NOT being pressed
 pub fn isMouseButtonUp(button: MouseButton) bool {
     return cdef.IsMouseButtonUp(button);
 }
 
+/// Get mouse position X
 pub fn getMouseX() i32 {
     return @as(i32, cdef.GetMouseX());
 }
 
+/// Get mouse position Y
 pub fn getMouseY() i32 {
     return @as(i32, cdef.GetMouseY());
 }
 
+/// Get mouse position XY
 pub fn getMousePosition() Vector2 {
     return cdef.GetMousePosition();
 }
 
+/// Get mouse delta between frames
 pub fn getMouseDelta() Vector2 {
     return cdef.GetMouseDelta();
 }
 
+/// Set mouse position XY
 pub fn setMousePosition(x: i32, y: i32) void {
     cdef.SetMousePosition(@as(c_int, x), @as(c_int, y));
 }
 
+/// Set mouse offset
 pub fn setMouseOffset(offsetX: i32, offsetY: i32) void {
     cdef.SetMouseOffset(@as(c_int, offsetX), @as(c_int, offsetY));
 }
 
+/// Set mouse scaling
 pub fn setMouseScale(scaleX: f32, scaleY: f32) void {
     cdef.SetMouseScale(scaleX, scaleY);
 }
 
+/// Get mouse wheel movement for X or Y, whichever is larger
 pub fn getMouseWheelMove() f32 {
     return cdef.GetMouseWheelMove();
 }
 
+/// Get mouse wheel movement for both X and Y
 pub fn getMouseWheelMoveV() Vector2 {
     return cdef.GetMouseWheelMoveV();
 }
 
+/// Set mouse cursor
 pub fn setMouseCursor(cursor: i32) void {
     cdef.SetMouseCursor(@as(c_int, cursor));
 }
 
+/// Get touch position X for touch point 0 (relative to screen size)
 pub fn getTouchX() i32 {
     return @as(i32, cdef.GetTouchX());
 }
 
+/// Get touch position Y for touch point 0 (relative to screen size)
 pub fn getTouchY() i32 {
     return @as(i32, cdef.GetTouchY());
 }
 
+/// Get touch position XY for a touch point index (relative to screen size)
 pub fn getTouchPosition(index: i32) Vector2 {
     return cdef.GetTouchPosition(@as(c_int, index));
 }
 
+/// Get touch point identifier for given index
 pub fn getTouchPointId(index: i32) i32 {
     return @as(i32, cdef.GetTouchPointId(@as(c_int, index)));
 }
 
+/// Get number of touch points
 pub fn getTouchPointCount() i32 {
     return @as(i32, cdef.GetTouchPointCount());
 }
 
+/// Enable a set of gestures using flags
 pub fn setGesturesEnabled(flags: Gesture) void {
     cdef.SetGesturesEnabled(flags);
 }
 
+/// Check if a gesture have been detected
 pub fn isGestureDetected(gesture: Gesture) bool {
     return cdef.IsGestureDetected(gesture);
 }
 
+/// Get latest detected gesture
 pub fn getGestureDetected() Gesture {
     return cdef.GetGestureDetected();
 }
 
+/// Get gesture hold time in milliseconds
 pub fn getGestureHoldDuration() f32 {
     return cdef.GetGestureHoldDuration();
 }
 
+/// Get gesture drag vector
 pub fn getGestureDragVector() Vector2 {
     return cdef.GetGestureDragVector();
 }
 
+/// Get gesture drag angle
 pub fn getGestureDragAngle() f32 {
     return cdef.GetGestureDragAngle();
 }
 
+/// Get gesture pinch delta
 pub fn getGesturePinchVector() Vector2 {
     return cdef.GetGesturePinchVector();
 }
 
+/// Get gesture pinch angle
 pub fn getGesturePinchAngle() f32 {
     return cdef.GetGesturePinchAngle();
 }
 
+/// Update camera position for selected mode
 pub fn updateCamera(camera: *Camera, mode: CameraMode) void {
     cdef.UpdateCamera(@as([*c]Camera, @ptrCast(camera)), mode);
 }
 
+/// Update camera movement/rotation
 pub fn updateCameraPro(camera: *Camera, movement: Vector3, rotation: Vector3, zoom: f32) void {
     cdef.UpdateCameraPro(@as([*c]Camera, @ptrCast(camera)), movement, rotation, zoom);
 }
 
+/// Set texture and rectangle to be used on shapes drawing
 pub fn setShapesTexture(texture: Texture2D, source: Rectangle) void {
     cdef.SetShapesTexture(texture, source);
 }
 
+/// Get texture that is used for shapes drawing
 pub fn getShapesTexture() Texture2D {
     return cdef.GetShapesTexture();
 }
 
+/// Get texture source rectangle that is used for shapes drawing
 pub fn getShapesTextureRectangle() Rectangle {
     return cdef.GetShapesTextureRectangle();
 }
 
+/// Draw a pixel
 pub fn drawPixel(posX: i32, posY: i32, color: Color) void {
     cdef.DrawPixel(@as(c_int, posX), @as(c_int, posY), color);
 }
 
+/// Draw a pixel (Vector version)
 pub fn drawPixelV(position: Vector2, color: Color) void {
     cdef.DrawPixelV(position, color);
 }
 
+/// Draw a line
 pub fn drawLine(startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
     cdef.DrawLine(@as(c_int, startPosX), @as(c_int, startPosY), @as(c_int, endPosX), @as(c_int, endPosY), color);
 }
 
+/// Draw a line (using gl lines)
 pub fn drawLineV(startPos: Vector2, endPos: Vector2, color: Color) void {
     cdef.DrawLineV(startPos, endPos, color);
 }
 
+/// Draw a line (using triangles/quads)
 pub fn drawLineEx(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) void {
     cdef.DrawLineEx(startPos, endPos, thick, color);
 }
 
+/// Draw line segment cubic-bezier in-out interpolation
 pub fn drawLineBezier(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) void {
     cdef.DrawLineBezier(startPos, endPos, thick, color);
 }
 
+/// Draw a color-filled circle
 pub fn drawCircle(centerX: i32, centerY: i32, radius: f32, color: Color) void {
     cdef.DrawCircle(@as(c_int, centerX), @as(c_int, centerY), radius, color);
 }
 
+/// Draw a piece of a circle
 pub fn drawCircleSector(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawCircleSector(center, radius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw circle sector outline
 pub fn drawCircleSectorLines(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawCircleSectorLines(center, radius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw a gradient-filled circle
 pub fn drawCircleGradient(centerX: i32, centerY: i32, radius: f32, color1: Color, color2: Color) void {
     cdef.DrawCircleGradient(@as(c_int, centerX), @as(c_int, centerY), radius, color1, color2);
 }
 
+/// Draw a color-filled circle (Vector version)
 pub fn drawCircleV(center: Vector2, radius: f32, color: Color) void {
     cdef.DrawCircleV(center, radius, color);
 }
 
+/// Draw circle outline
 pub fn drawCircleLines(centerX: i32, centerY: i32, radius: f32, color: Color) void {
     cdef.DrawCircleLines(@as(c_int, centerX), @as(c_int, centerY), radius, color);
 }
 
+/// Draw circle outline (Vector version)
 pub fn drawCircleLinesV(center: Vector2, radius: f32, color: Color) void {
     cdef.DrawCircleLinesV(center, radius, color);
 }
 
+/// Draw ellipse
 pub fn drawEllipse(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) void {
     cdef.DrawEllipse(@as(c_int, centerX), @as(c_int, centerY), radiusH, radiusV, color);
 }
 
+/// Draw ellipse outline
 pub fn drawEllipseLines(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) void {
     cdef.DrawEllipseLines(@as(c_int, centerX), @as(c_int, centerY), radiusH, radiusV, color);
 }
 
+/// Draw ring
 pub fn drawRing(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawRing(center, innerRadius, outerRadius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw ring outline
 pub fn drawRingLines(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawRingLines(center, innerRadius, outerRadius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw a color-filled rectangle
 pub fn drawRectangle(posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.DrawRectangle(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
+/// Draw a color-filled rectangle (Vector version)
 pub fn drawRectangleV(position: Vector2, size: Vector2, color: Color) void {
     cdef.DrawRectangleV(position, size, color);
 }
 
+/// Draw a color-filled rectangle
 pub fn drawRectangleRec(rec: Rectangle, color: Color) void {
     cdef.DrawRectangleRec(rec, color);
 }
 
+/// Draw a color-filled rectangle with pro parameters
 pub fn drawRectanglePro(rec: Rectangle, origin: Vector2, rotation: f32, color: Color) void {
     cdef.DrawRectanglePro(rec, origin, rotation, color);
 }
 
+/// Draw a vertical-gradient-filled rectangle
 pub fn drawRectangleGradientV(posX: i32, posY: i32, width: i32, height: i32, color1: Color, color2: Color) void {
     cdef.DrawRectangleGradientV(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color1, color2);
 }
 
+/// Draw a horizontal-gradient-filled rectangle
 pub fn drawRectangleGradientH(posX: i32, posY: i32, width: i32, height: i32, color1: Color, color2: Color) void {
     cdef.DrawRectangleGradientH(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color1, color2);
 }
 
+/// Draw a gradient-filled rectangle with custom vertex colors
 pub fn drawRectangleGradientEx(rec: Rectangle, col1: Color, col2: Color, col3: Color, col4: Color) void {
     cdef.DrawRectangleGradientEx(rec, col1, col2, col3, col4);
 }
 
+/// Draw rectangle outline
 pub fn drawRectangleLines(posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.DrawRectangleLines(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
+/// Draw rectangle outline with extended parameters
 pub fn drawRectangleLinesEx(rec: Rectangle, lineThick: f32, color: Color) void {
     cdef.DrawRectangleLinesEx(rec, lineThick, color);
 }
 
+/// Draw rectangle with rounded edges
 pub fn drawRectangleRounded(rec: Rectangle, roundness: f32, segments: i32, color: Color) void {
     cdef.DrawRectangleRounded(rec, roundness, @as(c_int, segments), color);
 }
 
+/// Draw rectangle lines with rounded edges
 pub fn drawRectangleRoundedLines(rec: Rectangle, roundness: f32, segments: i32, color: Color) void {
     cdef.DrawRectangleRoundedLines(rec, roundness, @as(c_int, segments), color);
 }
 
+/// Draw rectangle with rounded edges outline
 pub fn drawRectangleRoundedLinesEx(rec: Rectangle, roundness: f32, segments: i32, lineThick: f32, color: Color) void {
     cdef.DrawRectangleRoundedLinesEx(rec, roundness, @as(c_int, segments), lineThick, color);
 }
 
+/// Draw a color-filled triangle (vertex in counter-clockwise order!)
 pub fn drawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) void {
     cdef.DrawTriangle(v1, v2, v3, color);
 }
 
+/// Draw triangle outline (vertex in counter-clockwise order!)
 pub fn drawTriangleLines(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) void {
     cdef.DrawTriangleLines(v1, v2, v3, color);
 }
 
+/// Draw a regular polygon (Vector version)
 pub fn drawPoly(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) void {
     cdef.DrawPoly(center, @as(c_int, sides), radius, rotation, color);
 }
 
+/// Draw a polygon outline of n sides
 pub fn drawPolyLines(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) void {
     cdef.DrawPolyLines(center, @as(c_int, sides), radius, rotation, color);
 }
 
+/// Draw a polygon outline of n sides with extended parameters
 pub fn drawPolyLinesEx(center: Vector2, sides: i32, radius: f32, rotation: f32, lineThick: f32, color: Color) void {
     cdef.DrawPolyLinesEx(center, @as(c_int, sides), radius, rotation, lineThick, color);
 }
 
+/// Draw spline: Linear, minimum 2 points
 pub fn drawSplineLinear(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineLinear(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: B-Spline, minimum 4 points
 pub fn drawSplineBasis(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBasis(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: Catmull-Rom, minimum 4 points
 pub fn drawSplineCatmullRom(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineCatmullRom(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
 pub fn drawSplineBezierQuadratic(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBezierQuadratic(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
 pub fn drawSplineBezierCubic(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBezierCubic(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline segment: Linear, 2 points
 pub fn drawSplineSegmentLinear(p1: Vector2, p2: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentLinear(p1, p2, thick, color);
 }
 
+/// Draw spline segment: B-Spline, 4 points
 pub fn drawSplineSegmentBasis(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBasis(p1, p2, p3, p4, thick, color);
 }
 
+/// Draw spline segment: Catmull-Rom, 4 points
 pub fn drawSplineSegmentCatmullRom(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentCatmullRom(p1, p2, p3, p4, thick, color);
 }
 
+/// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
 pub fn drawSplineSegmentBezierQuadratic(p1: Vector2, c2: Vector2, p3: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBezierQuadratic(p1, c2, p3, thick, color);
 }
 
+/// Draw spline segment: Cubic Bezier, 2 points, 2 control points
 pub fn drawSplineSegmentBezierCubic(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBezierCubic(p1, c2, c3, p4, thick, color);
 }
 
+/// Get (evaluate) spline point: Linear
 pub fn getSplinePointLinear(startPos: Vector2, endPos: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointLinear(startPos, endPos, t);
 }
 
+/// Get (evaluate) spline point: B-Spline
 pub fn getSplinePointBasis(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBasis(p1, p2, p3, p4, t);
 }
 
+/// Get (evaluate) spline point: Catmull-Rom
 pub fn getSplinePointCatmullRom(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointCatmullRom(p1, p2, p3, p4, t);
 }
 
+/// Get (evaluate) spline point: Quadratic Bezier
 pub fn getSplinePointBezierQuad(p1: Vector2, c2: Vector2, p3: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBezierQuad(p1, c2, p3, t);
 }
 
+/// Get (evaluate) spline point: Cubic Bezier
 pub fn getSplinePointBezierCubic(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBezierCubic(p1, c2, c3, p4, t);
 }
 
+/// Check collision between two rectangles
 pub fn checkCollisionRecs(rec1: Rectangle, rec2: Rectangle) bool {
     return cdef.CheckCollisionRecs(rec1, rec2);
 }
 
+/// Check collision between two circles
 pub fn checkCollisionCircles(center1: Vector2, radius1: f32, center2: Vector2, radius2: f32) bool {
     return cdef.CheckCollisionCircles(center1, radius1, center2, radius2);
 }
 
+/// Check collision between circle and rectangle
 pub fn checkCollisionCircleRec(center: Vector2, radius: f32, rec: Rectangle) bool {
     return cdef.CheckCollisionCircleRec(center, radius, rec);
 }
 
+/// Check if point is inside rectangle
 pub fn checkCollisionPointRec(point: Vector2, rec: Rectangle) bool {
     return cdef.CheckCollisionPointRec(point, rec);
 }
 
+/// Check if point is inside circle
 pub fn checkCollisionPointCircle(point: Vector2, center: Vector2, radius: f32) bool {
     return cdef.CheckCollisionPointCircle(point, center, radius);
 }
 
+/// Check if point is inside a triangle
 pub fn checkCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) bool {
     return cdef.CheckCollisionPointTriangle(point, p1, p2, p3);
 }
 
+/// Check the collision between two lines defined by two points each, returns collision point by reference
 pub fn checkCollisionLines(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: *Vector2) bool {
     return cdef.CheckCollisionLines(startPos1, endPos1, startPos2, endPos2, @as([*c]Vector2, @ptrCast(collisionPoint)));
 }
 
+/// Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
 pub fn checkCollisionPointLine(point: Vector2, p1: Vector2, p2: Vector2, threshold: i32) bool {
     return cdef.CheckCollisionPointLine(point, p1, p2, @as(c_int, threshold));
 }
 
+/// Check if circle collides with a line created betweeen two points [p1] and [p2]
 pub fn checkCollisionCircleLine(center: Vector2, radius: f32, p1: Vector2, p2: Vector2) bool {
     return cdef.CheckCollisionCircleLine(center, radius, p1, p2);
 }
 
+/// Get collision rectangle for two rectangles collision
 pub fn getCollisionRec(rec1: Rectangle, rec2: Rectangle) Rectangle {
     return cdef.GetCollisionRec(rec1, rec2);
 }
 
+/// Load image from file into CPU memory (RAM)
 pub fn loadImage(fileName: [:0]const u8) Image {
     return cdef.LoadImage(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load image from RAW file data
 pub fn loadImageRaw(fileName: [:0]const u8, width: i32, height: i32, format: PixelFormat, headerSize: i32) Image {
     return cdef.LoadImageRaw(@as([*c]const u8, @ptrCast(fileName)), @as(c_int, width), @as(c_int, height), format, @as(c_int, headerSize));
 }
 
+/// Load image from SVG file data or string with specified size
 pub fn loadImageSvg(fileNameOrString: [:0]const u8, width: i32, height: i32) Image {
     return cdef.LoadImageSvg(@as([*c]const u8, @ptrCast(fileNameOrString)), @as(c_int, width), @as(c_int, height));
 }
 
+/// Load image sequence from file (frames appended to image.data)
 pub fn loadImageAnim(fileName: [:0]const u8, frames: *i32) Image {
     return cdef.LoadImageAnim(@as([*c]const u8, @ptrCast(fileName)), @as([*c]c_int, @ptrCast(frames)));
 }
 
+/// Load image from GPU texture data
 pub fn loadImageFromTexture(texture: Texture2D) Image {
     return cdef.LoadImageFromTexture(texture);
 }
 
+/// Load image from screen buffer and (screenshot)
 pub fn loadImageFromScreen() Image {
     return cdef.LoadImageFromScreen();
 }
 
+/// Check if an image is ready
 pub fn isImageReady(image: Image) bool {
     return cdef.IsImageReady(image);
 }
 
+/// Unload image from CPU memory (RAM)
 pub fn unloadImage(image: Image) void {
     cdef.UnloadImage(image);
 }
 
+/// Export image data to file, returns true on success
 pub fn exportImage(image: Image, fileName: [:0]const u8) bool {
     return cdef.ExportImage(image, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Export image to memory buffer
 pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) [:0]u8 {
     return std.mem.span(cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize))));
 }
 
+/// Export image as code file defining an array of bytes, returns true on success
 pub fn exportImageAsCode(image: Image, fileName: [:0]const u8) bool {
     return cdef.ExportImageAsCode(image, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Generate image: plain color
 pub fn genImageColor(width: i32, height: i32, color: Color) Image {
     return cdef.GenImageColor(@as(c_int, width), @as(c_int, height), color);
 }
 
+/// Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
 pub fn genImageGradientLinear(width: i32, height: i32, direction: i32, start: Color, end: Color) Image {
     return cdef.GenImageGradientLinear(@as(c_int, width), @as(c_int, height), @as(c_int, direction), start, end);
 }
 
+/// Generate image: radial gradient
 pub fn genImageGradientRadial(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
     return cdef.GenImageGradientRadial(@as(c_int, width), @as(c_int, height), density, inner, outer);
 }
 
+/// Generate image: square gradient
 pub fn genImageGradientSquare(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
     return cdef.GenImageGradientSquare(@as(c_int, width), @as(c_int, height), density, inner, outer);
 }
 
+/// Generate image: checked
 pub fn genImageChecked(width: i32, height: i32, checksX: i32, checksY: i32, col1: Color, col2: Color) Image {
     return cdef.GenImageChecked(@as(c_int, width), @as(c_int, height), @as(c_int, checksX), @as(c_int, checksY), col1, col2);
 }
 
+/// Generate image: white noise
 pub fn genImageWhiteNoise(width: i32, height: i32, factor: f32) Image {
     return cdef.GenImageWhiteNoise(@as(c_int, width), @as(c_int, height), factor);
 }
 
+/// Generate image: perlin noise
 pub fn genImagePerlinNoise(width: i32, height: i32, offsetX: i32, offsetY: i32, scale: f32) Image {
     return cdef.GenImagePerlinNoise(@as(c_int, width), @as(c_int, height), @as(c_int, offsetX), @as(c_int, offsetY), scale);
 }
 
+/// Generate image: cellular algorithm, bigger tileSize means bigger cells
 pub fn genImageCellular(width: i32, height: i32, tileSize: i32) Image {
     return cdef.GenImageCellular(@as(c_int, width), @as(c_int, height), @as(c_int, tileSize));
 }
 
+/// Generate image: grayscale image from text data
 pub fn genImageText(width: i32, height: i32, text: [:0]const u8) Image {
     return cdef.GenImageText(@as(c_int, width), @as(c_int, height), @as([*c]const u8, @ptrCast(text)));
 }
 
+/// Create an image duplicate (useful for transformations)
 pub fn imageCopy(image: Image) Image {
     return cdef.ImageCopy(image);
 }
 
+/// Create an image from another image piece
 pub fn imageFromImage(image: Image, rec: Rectangle) Image {
     return cdef.ImageFromImage(image, rec);
 }
 
+/// Create an image from text (default font)
 pub fn imageText(text: [:0]const u8, fontSize: i32, color: Color) Image {
     return cdef.ImageText(@as([*c]const u8, @ptrCast(text)), @as(c_int, fontSize), color);
 }
 
+/// Create an image from text (custom sprite font)
 pub fn imageTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32, tint: Color) Image {
     return cdef.ImageTextEx(font, @as([*c]const u8, @ptrCast(text)), fontSize, spacing, tint);
 }
 
+/// Convert image data to desired format
 pub fn imageFormat(image: *Image, newFormat: PixelFormat) void {
     cdef.ImageFormat(@as([*c]Image, @ptrCast(image)), newFormat);
 }
 
+/// Convert image to POT (power-of-two)
 pub fn imageToPOT(image: *Image, fill: Color) void {
     cdef.ImageToPOT(@as([*c]Image, @ptrCast(image)), fill);
 }
 
+/// Crop an image to a defined rectangle
 pub fn imageCrop(image: *Image, crop: Rectangle) void {
     cdef.ImageCrop(@as([*c]Image, @ptrCast(image)), crop);
 }
 
+/// Crop image depending on alpha value
 pub fn imageAlphaCrop(image: *Image, threshold: f32) void {
     cdef.ImageAlphaCrop(@as([*c]Image, @ptrCast(image)), threshold);
 }
 
+/// Clear alpha channel to desired color
 pub fn imageAlphaClear(image: *Image, color: Color, threshold: f32) void {
     cdef.ImageAlphaClear(@as([*c]Image, @ptrCast(image)), color, threshold);
 }
 
+/// Apply alpha mask to image
 pub fn imageAlphaMask(image: *Image, alphaMask: Image) void {
     cdef.ImageAlphaMask(@as([*c]Image, @ptrCast(image)), alphaMask);
 }
 
+/// Premultiply alpha channel
 pub fn imageAlphaPremultiply(image: *Image) void {
     cdef.ImageAlphaPremultiply(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Apply Gaussian blur using a box blur approximation
 pub fn imageBlurGaussian(image: *Image, blurSize: i32) void {
     cdef.ImageBlurGaussian(@as([*c]Image, @ptrCast(image)), @as(c_int, blurSize));
 }
 
+/// Apply Custom Square image convolution kernel
 pub fn imageKernelConvolution(image: *Image, kernel: []f32, kernelSize: i32) void {
     cdef.ImageKernelConvolution(@as([*c]Image, @ptrCast(image)), @as([*c]f32, @ptrCast(kernel)), @as(c_int, kernelSize));
 }
 
+/// Resize image (Bicubic scaling algorithm)
 pub fn imageResize(image: *Image, newWidth: i32, newHeight: i32) void {
     cdef.ImageResize(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight));
 }
 
+/// Resize image (Nearest-Neighbor scaling algorithm)
 pub fn imageResizeNN(image: *Image, newWidth: i32, newHeight: i32) void {
     cdef.ImageResizeNN(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight));
 }
 
+/// Resize canvas and fill with color
 pub fn imageResizeCanvas(image: *Image, newWidth: i32, newHeight: i32, offsetX: i32, offsetY: i32, fill: Color) void {
     cdef.ImageResizeCanvas(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight), @as(c_int, offsetX), @as(c_int, offsetY), fill);
 }
 
+/// Compute all mipmap levels for a provided image
 pub fn imageMipmaps(image: *Image) void {
     cdef.ImageMipmaps(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
 pub fn imageDither(image: *Image, rBpp: i32, gBpp: i32, bBpp: i32, aBpp: i32) void {
     cdef.ImageDither(@as([*c]Image, @ptrCast(image)), @as(c_int, rBpp), @as(c_int, gBpp), @as(c_int, bBpp), @as(c_int, aBpp));
 }
 
+/// Flip image vertically
 pub fn imageFlipVertical(image: *Image) void {
     cdef.ImageFlipVertical(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Flip image horizontally
 pub fn imageFlipHorizontal(image: *Image) void {
     cdef.ImageFlipHorizontal(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Rotate image by input angle in degrees (-359 to 359)
 pub fn imageRotate(image: *Image, degrees: i32) void {
     cdef.ImageRotate(@as([*c]Image, @ptrCast(image)), @as(c_int, degrees));
 }
 
+/// Rotate image clockwise 90deg
 pub fn imageRotateCW(image: *Image) void {
     cdef.ImageRotateCW(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Rotate image counter-clockwise 90deg
 pub fn imageRotateCCW(image: *Image) void {
     cdef.ImageRotateCCW(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Modify image color: tint
 pub fn imageColorTint(image: *Image, color: Color) void {
     cdef.ImageColorTint(@as([*c]Image, @ptrCast(image)), color);
 }
 
+/// Modify image color: invert
 pub fn imageColorInvert(image: *Image) void {
     cdef.ImageColorInvert(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Modify image color: grayscale
 pub fn imageColorGrayscale(image: *Image) void {
     cdef.ImageColorGrayscale(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Modify image color: contrast (-100 to 100)
 pub fn imageColorContrast(image: *Image, contrast: f32) void {
     cdef.ImageColorContrast(@as([*c]Image, @ptrCast(image)), contrast);
 }
 
+/// Modify image color: brightness (-255 to 255)
 pub fn imageColorBrightness(image: *Image, brightness: i32) void {
     cdef.ImageColorBrightness(@as([*c]Image, @ptrCast(image)), @as(c_int, brightness));
 }
 
+/// Modify image color: replace color
 pub fn imageColorReplace(image: *Image, color: Color, replace: Color) void {
     cdef.ImageColorReplace(@as([*c]Image, @ptrCast(image)), color, replace);
 }
 
+/// Unload color data loaded with LoadImageColors()
 pub fn unloadImageColors(colors: []Color) void {
     cdef.UnloadImageColors(@as([*c]Color, @ptrCast(colors)));
 }
 
+/// Unload colors palette loaded with LoadImagePalette()
 pub fn unloadImagePalette(colors: []Color) void {
     cdef.UnloadImagePalette(@as([*c]Color, @ptrCast(colors)));
 }
 
+/// Get image alpha border rectangle
 pub fn getImageAlphaBorder(image: Image, threshold: f32) Rectangle {
     return cdef.GetImageAlphaBorder(image, threshold);
 }
 
+/// Get image pixel color at (x, y) position
 pub fn getImageColor(image: Image, x: i32, y: i32) Color {
     return cdef.GetImageColor(image, @as(c_int, x), @as(c_int, y));
 }
 
+/// Clear image background with given color
 pub fn imageClearBackground(dst: *Image, color: Color) void {
     cdef.ImageClearBackground(@as([*c]Image, @ptrCast(dst)), color);
 }
 
+/// Draw pixel within an image
 pub fn imageDrawPixel(dst: *Image, posX: i32, posY: i32, color: Color) void {
     cdef.ImageDrawPixel(@as([*c]Image, @ptrCast(dst)), @as(c_int, posX), @as(c_int, posY), color);
 }
 
+/// Draw pixel within an image (Vector version)
 pub fn imageDrawPixelV(dst: *Image, position: Vector2, color: Color) void {
     cdef.ImageDrawPixelV(@as([*c]Image, @ptrCast(dst)), position, color);
 }
 
+/// Draw line within an image
 pub fn imageDrawLine(dst: *Image, startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
     cdef.ImageDrawLine(@as([*c]Image, @ptrCast(dst)), @as(c_int, startPosX), @as(c_int, startPosY), @as(c_int, endPosX), @as(c_int, endPosY), color);
 }
 
+/// Draw line within an image (Vector version)
 pub fn imageDrawLineV(dst: *Image, start: Vector2, end: Vector2, color: Color) void {
     cdef.ImageDrawLineV(@as([*c]Image, @ptrCast(dst)), start, end, color);
 }
 
+/// Draw a filled circle within an image
 pub fn imageDrawCircle(dst: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
     cdef.ImageDrawCircle(@as([*c]Image, @ptrCast(dst)), @as(c_int, centerX), @as(c_int, centerY), @as(c_int, radius), color);
 }
 
+/// Draw a filled circle within an image (Vector version)
 pub fn imageDrawCircleV(dst: *Image, center: Vector2, radius: i32, color: Color) void {
     cdef.ImageDrawCircleV(@as([*c]Image, @ptrCast(dst)), center, @as(c_int, radius), color);
 }
 
+/// Draw circle outline within an image
 pub fn imageDrawCircleLines(dst: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
     cdef.ImageDrawCircleLines(@as([*c]Image, @ptrCast(dst)), @as(c_int, centerX), @as(c_int, centerY), @as(c_int, radius), color);
 }
 
+/// Draw circle outline within an image (Vector version)
 pub fn imageDrawCircleLinesV(dst: *Image, center: Vector2, radius: i32, color: Color) void {
     cdef.ImageDrawCircleLinesV(@as([*c]Image, @ptrCast(dst)), center, @as(c_int, radius), color);
 }
 
+/// Draw rectangle within an image
 pub fn imageDrawRectangle(dst: *Image, posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.ImageDrawRectangle(@as([*c]Image, @ptrCast(dst)), @as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
+/// Draw rectangle within an image (Vector version)
 pub fn imageDrawRectangleV(dst: *Image, position: Vector2, size: Vector2, color: Color) void {
     cdef.ImageDrawRectangleV(@as([*c]Image, @ptrCast(dst)), position, size, color);
 }
 
+/// Draw rectangle within an image
 pub fn imageDrawRectangleRec(dst: *Image, rec: Rectangle, color: Color) void {
     cdef.ImageDrawRectangleRec(@as([*c]Image, @ptrCast(dst)), rec, color);
 }
 
+/// Draw rectangle lines within an image
 pub fn imageDrawRectangleLines(dst: *Image, rec: Rectangle, thick: i32, color: Color) void {
     cdef.ImageDrawRectangleLines(@as([*c]Image, @ptrCast(dst)), rec, @as(c_int, thick), color);
 }
 
+/// Draw a source image within a destination image (tint applied to source)
 pub fn imageDraw(dst: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color) void {
     cdef.ImageDraw(@as([*c]Image, @ptrCast(dst)), src, srcRec, dstRec, tint);
 }
 
+/// Draw text (using default font) within an image (destination)
 pub fn imageDrawText(dst: *Image, text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
     cdef.ImageDrawText(@as([*c]Image, @ptrCast(dst)), @as([*c]const u8, @ptrCast(text)), @as(c_int, posX), @as(c_int, posY), @as(c_int, fontSize), color);
 }
 
+/// Draw text (custom sprite font) within an image (destination)
 pub fn imageDrawTextEx(dst: *Image, font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.ImageDrawTextEx(@as([*c]Image, @ptrCast(dst)), font, @as([*c]const u8, @ptrCast(text)), position, fontSize, spacing, tint);
 }
 
+/// Load texture from file into GPU memory (VRAM)
 pub fn loadTexture(fileName: [:0]const u8) Texture2D {
     return cdef.LoadTexture(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load texture from image data
 pub fn loadTextureFromImage(image: Image) Texture2D {
     return cdef.LoadTextureFromImage(image);
 }
 
+/// Load cubemap from image, multiple image cubemap layouts supported
 pub fn loadTextureCubemap(image: Image, layout: CubemapLayout) TextureCubemap {
     return cdef.LoadTextureCubemap(image, layout);
 }
 
+/// Load texture for rendering (framebuffer)
 pub fn loadRenderTexture(width: i32, height: i32) RenderTexture2D {
     return cdef.LoadRenderTexture(@as(c_int, width), @as(c_int, height));
 }
 
+/// Check if a texture is ready
 pub fn isTextureReady(texture: Texture2D) bool {
     return cdef.IsTextureReady(texture);
 }
 
+/// Unload texture from GPU memory (VRAM)
 pub fn unloadTexture(texture: Texture2D) void {
     cdef.UnloadTexture(texture);
 }
 
+/// Check if a render texture is ready
 pub fn isRenderTextureReady(target: RenderTexture2D) bool {
     return cdef.IsRenderTextureReady(target);
 }
 
+/// Unload render texture from GPU memory (VRAM)
 pub fn unloadRenderTexture(target: RenderTexture2D) void {
     cdef.UnloadRenderTexture(target);
 }
 
+/// Update GPU texture with new data
 pub fn updateTexture(texture: Texture2D, pixels: *const anyopaque) void {
     cdef.UpdateTexture(texture, pixels);
 }
 
+/// Update GPU texture rectangle with new data
 pub fn updateTextureRec(texture: Texture2D, rec: Rectangle, pixels: *const anyopaque) void {
     cdef.UpdateTextureRec(texture, rec, pixels);
 }
 
+/// Generate GPU mipmaps for a texture
 pub fn genTextureMipmaps(texture: *Texture2D) void {
     cdef.GenTextureMipmaps(@as([*c]Texture2D, @ptrCast(texture)));
 }
 
+/// Set texture scaling filter mode
 pub fn setTextureFilter(texture: Texture2D, filter: TextureFilter) void {
     cdef.SetTextureFilter(texture, filter);
 }
 
+/// Set texture wrapping mode
 pub fn setTextureWrap(texture: Texture2D, wrap: i32) void {
     cdef.SetTextureWrap(texture, @as(c_int, wrap));
 }
 
+/// Draw a Texture2D
 pub fn drawTexture(texture: Texture2D, posX: i32, posY: i32, tint: Color) void {
     cdef.DrawTexture(texture, @as(c_int, posX), @as(c_int, posY), tint);
 }
 
+/// Draw a Texture2D with position defined as Vector2
 pub fn drawTextureV(texture: Texture2D, position: Vector2, tint: Color) void {
     cdef.DrawTextureV(texture, position, tint);
 }
 
+/// Draw a Texture2D with extended parameters
 pub fn drawTextureEx(texture: Texture2D, position: Vector2, rotation: f32, scale: f32, tint: Color) void {
     cdef.DrawTextureEx(texture, position, rotation, scale, tint);
 }
 
+/// Draw a part of a texture defined by a rectangle
 pub fn drawTextureRec(texture: Texture2D, source: Rectangle, position: Vector2, tint: Color) void {
     cdef.DrawTextureRec(texture, source, position, tint);
 }
 
+/// Draw a part of a texture defined by a rectangle with 'pro' parameters
 pub fn drawTexturePro(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawTexturePro(texture, source, dest, origin, rotation, tint);
 }
 
+/// Draws a texture (or part of it) that stretches or shrinks nicely
 pub fn drawTextureNPatch(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawTextureNPatch(texture, nPatchInfo, dest, origin, rotation, tint);
 }
 
+/// Check if two colors are equal
 pub fn colorIsEqual(col1: Color, col2: Color) bool {
     return cdef.ColorIsEqual(col1, col2);
 }
 
+/// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn fade(color: Color, alpha: f32) Color {
     return cdef.Fade(color, alpha);
 }
 
+/// Get hexadecimal value for a Color (0xRRGGBBAA)
 pub fn colorToInt(color: Color) i32 {
     return @as(i32, cdef.ColorToInt(color));
 }
 
+/// Get Color normalized as float [0..1]
 pub fn colorNormalize(color: Color) Vector4 {
     return cdef.ColorNormalize(color);
 }
 
+/// Get Color from normalized values [0..1]
 pub fn colorFromNormalized(normalized: Vector4) Color {
     return cdef.ColorFromNormalized(normalized);
 }
 
+/// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
 pub fn colorToHSV(color: Color) Vector3 {
     return cdef.ColorToHSV(color);
 }
 
+/// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
 pub fn colorFromHSV(hue: f32, saturation: f32, value: f32) Color {
     return cdef.ColorFromHSV(hue, saturation, value);
 }
 
+/// Get color multiplied with another color
 pub fn colorTint(color: Color, tint: Color) Color {
     return cdef.ColorTint(color, tint);
 }
 
+/// Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
 pub fn colorBrightness(color: Color, factor: f32) Color {
     return cdef.ColorBrightness(color, factor);
 }
 
+/// Get color with contrast correction, contrast values between -1.0f and 1.0f
 pub fn colorContrast(color: Color, contrast: f32) Color {
     return cdef.ColorContrast(color, contrast);
 }
 
+/// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn colorAlpha(color: Color, alpha: f32) Color {
     return cdef.ColorAlpha(color, alpha);
 }
 
+/// Get src alpha-blended into dst color with tint
 pub fn colorAlphaBlend(dst: Color, src: Color, tint: Color) Color {
     return cdef.ColorAlphaBlend(dst, src, tint);
 }
 
+/// Get Color structure from hexadecimal value
 pub fn getColor(hexValue: u32) Color {
     return cdef.GetColor(@as(c_uint, hexValue));
 }
 
+/// Get Color from a source pixel pointer of certain format
 pub fn getPixelColor(srcPtr: *anyopaque, format: PixelFormat) Color {
     return cdef.GetPixelColor(srcPtr, format);
 }
 
+/// Set color formatted into destination pixel pointer
 pub fn setPixelColor(dstPtr: *anyopaque, color: Color, format: PixelFormat) void {
     cdef.SetPixelColor(dstPtr, color, format);
 }
 
+/// Get pixel data size in bytes for certain format
 pub fn getPixelDataSize(width: i32, height: i32, format: PixelFormat) i32 {
     return @as(i32, cdef.GetPixelDataSize(@as(c_int, width), @as(c_int, height), format));
 }
 
+/// Get the default Font
 pub fn getFontDefault() Font {
     return cdef.GetFontDefault();
 }
 
+/// Load font from file into GPU memory (VRAM)
 pub fn loadFont(fileName: [:0]const u8) Font {
     return cdef.LoadFont(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load font from Image (XNA style)
 pub fn loadFontFromImage(image: Image, key: Color, firstChar: i32) Font {
     return cdef.LoadFontFromImage(image, key, @as(c_int, firstChar));
 }
 
+/// Check if a font is ready
 pub fn isFontReady(font: Font) bool {
     return cdef.IsFontReady(font);
 }
 
+/// Unload font from GPU memory (VRAM)
 pub fn unloadFont(font: Font) void {
     cdef.UnloadFont(font);
 }
 
+/// Export font as code file, returns true on success
 pub fn exportFontAsCode(font: Font, fileName: [:0]const u8) bool {
     return cdef.ExportFontAsCode(font, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Draw current FPS
 pub fn drawFPS(posX: i32, posY: i32) void {
     cdef.DrawFPS(@as(c_int, posX), @as(c_int, posY));
 }
 
+/// Draw text (using default font)
 pub fn drawText(text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
     cdef.DrawText(@as([*c]const u8, @ptrCast(text)), @as(c_int, posX), @as(c_int, posY), @as(c_int, fontSize), color);
 }
 
+/// Draw text using font and additional parameters
 pub fn drawTextEx(font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.DrawTextEx(font, @as([*c]const u8, @ptrCast(text)), position, fontSize, spacing, tint);
 }
 
+/// Draw text using Font and pro parameters (rotation)
 pub fn drawTextPro(font: Font, text: [:0]const u8, position: Vector2, origin: Vector2, rotation: f32, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.DrawTextPro(font, @as([*c]const u8, @ptrCast(text)), position, origin, rotation, fontSize, spacing, tint);
 }
 
+/// Draw one character (codepoint)
 pub fn drawTextCodepoint(font: Font, codepoint: i32, position: Vector2, fontSize: f32, tint: Color) void {
     cdef.DrawTextCodepoint(font, @as(c_int, codepoint), position, fontSize, tint);
 }
 
+/// Set vertical line spacing when drawing with line-breaks
 pub fn setTextLineSpacing(spacing: i32) void {
     cdef.SetTextLineSpacing(@as(c_int, spacing));
 }
 
+/// Measure string width for default font
 pub fn measureText(text: [:0]const u8, fontSize: i32) i32 {
     return @as(i32, cdef.MeasureText(@as([*c]const u8, @ptrCast(text)), @as(c_int, fontSize)));
 }
 
+/// Measure string size for Font
 pub fn measureTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32) Vector2 {
     return cdef.MeasureTextEx(font, @as([*c]const u8, @ptrCast(text)), fontSize, spacing);
 }
 
+/// Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphIndex(font: Font, codepoint: i32) i32 {
     return @as(i32, cdef.GetGlyphIndex(font, @as(c_int, codepoint)));
 }
 
+/// Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphInfo(font: Font, codepoint: i32) GlyphInfo {
     return cdef.GetGlyphInfo(font, @as(c_int, codepoint));
 }
 
+/// Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphAtlasRec(font: Font, codepoint: i32) Rectangle {
     return cdef.GetGlyphAtlasRec(font, @as(c_int, codepoint));
 }
 
+/// Unload UTF-8 text encoded from codepoints array
 pub fn unloadUTF8(text: [:0]u8) void {
     cdef.UnloadUTF8(@as([*c]u8, @ptrCast(text)));
 }
 
+/// Unload codepoints data from memory
 pub fn unloadCodepoints(codepoints: []i32) void {
     cdef.UnloadCodepoints(@as([*c]c_int, @ptrCast(codepoints)));
 }
 
+/// Get total number of codepoints in a UTF-8 encoded string
 pub fn getCodepointCount(text: [:0]const u8) i32 {
     return @as(i32, cdef.GetCodepointCount(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepoint(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepoint(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
+/// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepointNext(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepointNext(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
+/// Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepointPrevious(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepointPrevious(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
+/// Encode one codepoint into UTF-8 byte array (array length returned as parameter)
 pub fn codepointToUTF8(codepoint: i32, utf8Size: *i32) [:0]const u8 {
     return std.mem.span(cdef.CodepointToUTF8(@as(c_int, codepoint), @as([*c]c_int, @ptrCast(utf8Size))));
 }
 
+/// Copy one string to another, returns bytes copied
 pub fn textCopy(dst: *u8, src: [:0]const u8) i32 {
     return @as(i32, cdef.TextCopy(@as([*c]u8, @ptrCast(dst)), @as([*c]const u8, @ptrCast(src))));
 }
 
+/// Check if two text string are equal
 pub fn textIsEqual(text1: [:0]const u8, text2: [:0]const u8) bool {
     return cdef.TextIsEqual(@as([*c]const u8, @ptrCast(text1)), @as([*c]const u8, @ptrCast(text2)));
 }
 
+/// Get text length, checks for '\0' ending
 pub fn textLength(text: [:0]const u8) u32 {
     return @as(u32, cdef.TextLength(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get a piece of a text string
 pub fn textSubtext(text: [:0]const u8, position: i32, length: i32) [:0]const u8 {
     return std.mem.span(cdef.TextSubtext(@as([*c]const u8, @ptrCast(text)), @as(c_int, position), @as(c_int, length)));
 }
 
+/// Replace text string (WARNING: memory must be freed!)
 pub fn textReplace(text: [:0]const u8, replace: [:0]const u8, by: [:0]const u8) [:0]u8 {
     return std.mem.span(cdef.TextReplace(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(replace)), @as([*c]const u8, @ptrCast(by))));
 }
 
+/// Insert text in a position (WARNING: memory must be freed!)
 pub fn textInsert(text: [:0]const u8, insert: [:0]const u8, position: i32) [:0]u8 {
     return std.mem.span(cdef.TextInsert(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(insert)), @as(c_int, position)));
 }
 
+/// Append text at specific position and move cursor!
 pub fn textAppend(text: [:0]u8, append: [:0]const u8, position: *i32) void {
     cdef.TextAppend(@as([*c]u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(append)), @as([*c]c_int, @ptrCast(position)));
 }
 
+/// Find first text occurrence within a string
 pub fn textFindIndex(text: [:0]const u8, find: [:0]const u8) i32 {
     return @as(i32, cdef.TextFindIndex(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(find))));
 }
 
+/// Get upper case version of provided string
 pub fn textToUpper(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToUpper(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get lower case version of provided string
 pub fn textToLower(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToLower(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get Pascal case notation version of provided string
 pub fn textToPascal(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToPascal(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get Snake case notation version of provided string
 pub fn textToSnake(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToSnake(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get Camel case notation version of provided string
 pub fn textToCamel(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToCamel(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get integer value from text (negative values not supported)
 pub fn textToInteger(text: [:0]const u8) i32 {
     return @as(i32, cdef.TextToInteger(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get float value from text (negative values not supported)
 pub fn textToFloat(text: [:0]const u8) f32 {
     return cdef.TextToFloat(@as([*c]const u8, @ptrCast(text)));
 }
 
+/// Draw a line in 3D world space
 pub fn drawLine3D(startPos: Vector3, endPos: Vector3, color: Color) void {
     cdef.DrawLine3D(startPos, endPos, color);
 }
 
+/// Draw a point in 3D space, actually a small line
 pub fn drawPoint3D(position: Vector3, color: Color) void {
     cdef.DrawPoint3D(position, color);
 }
 
+/// Draw a circle in 3D world space
 pub fn drawCircle3D(center: Vector3, radius: f32, rotationAxis: Vector3, rotationAngle: f32, color: Color) void {
     cdef.DrawCircle3D(center, radius, rotationAxis, rotationAngle, color);
 }
 
+/// Draw a color-filled triangle (vertex in counter-clockwise order!)
 pub fn drawTriangle3D(v1: Vector3, v2: Vector3, v3: Vector3, color: Color) void {
     cdef.DrawTriangle3D(v1, v2, v3, color);
 }
 
+/// Draw cube
 pub fn drawCube(position: Vector3, width: f32, height: f32, length: f32, color: Color) void {
     cdef.DrawCube(position, width, height, length, color);
 }
 
+/// Draw cube (Vector version)
 pub fn drawCubeV(position: Vector3, size: Vector3, color: Color) void {
     cdef.DrawCubeV(position, size, color);
 }
 
+/// Draw cube wires
 pub fn drawCubeWires(position: Vector3, width: f32, height: f32, length: f32, color: Color) void {
     cdef.DrawCubeWires(position, width, height, length, color);
 }
 
+/// Draw cube wires (Vector version)
 pub fn drawCubeWiresV(position: Vector3, size: Vector3, color: Color) void {
     cdef.DrawCubeWiresV(position, size, color);
 }
 
+/// Draw sphere
 pub fn drawSphere(centerPos: Vector3, radius: f32, color: Color) void {
     cdef.DrawSphere(centerPos, radius, color);
 }
 
+/// Draw sphere with extended parameters
 pub fn drawSphereEx(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) void {
     cdef.DrawSphereEx(centerPos, radius, @as(c_int, rings), @as(c_int, slices), color);
 }
 
+/// Draw sphere wires
 pub fn drawSphereWires(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) void {
     cdef.DrawSphereWires(centerPos, radius, @as(c_int, rings), @as(c_int, slices), color);
 }
 
+/// Draw a cylinder/cone
 pub fn drawCylinder(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) void {
     cdef.DrawCylinder(position, radiusTop, radiusBottom, height, @as(c_int, slices), color);
 }
 
+/// Draw a cylinder with base at startPos and top at endPos
 pub fn drawCylinderEx(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) void {
     cdef.DrawCylinderEx(startPos, endPos, startRadius, endRadius, @as(c_int, sides), color);
 }
 
+/// Draw a cylinder/cone wires
 pub fn drawCylinderWires(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) void {
     cdef.DrawCylinderWires(position, radiusTop, radiusBottom, height, @as(c_int, slices), color);
 }
 
+/// Draw a cylinder wires with base at startPos and top at endPos
 pub fn drawCylinderWiresEx(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) void {
     cdef.DrawCylinderWiresEx(startPos, endPos, startRadius, endRadius, @as(c_int, sides), color);
 }
 
+/// Draw a capsule with the center of its sphere caps at startPos and endPos
 pub fn drawCapsule(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) void {
     cdef.DrawCapsule(startPos, endPos, radius, @as(c_int, slices), @as(c_int, rings), color);
 }
 
+/// Draw capsule wireframe with the center of its sphere caps at startPos and endPos
 pub fn drawCapsuleWires(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) void {
     cdef.DrawCapsuleWires(startPos, endPos, radius, @as(c_int, slices), @as(c_int, rings), color);
 }
 
+/// Draw a plane XZ
 pub fn drawPlane(centerPos: Vector3, size: Vector2, color: Color) void {
     cdef.DrawPlane(centerPos, size, color);
 }
 
+/// Draw a ray line
 pub fn drawRay(ray: Ray, color: Color) void {
     cdef.DrawRay(ray, color);
 }
 
+/// Draw a grid (centered at (0, 0, 0))
 pub fn drawGrid(slices: i32, spacing: f32) void {
     cdef.DrawGrid(@as(c_int, slices), spacing);
 }
 
+/// Load model from files (meshes and materials)
 pub fn loadModel(fileName: [:0]const u8) Model {
     return cdef.LoadModel(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load model from generated mesh (default material)
 pub fn loadModelFromMesh(mesh: Mesh) Model {
     return cdef.LoadModelFromMesh(mesh);
 }
 
+/// Check if a model is ready
 pub fn isModelReady(model: Model) bool {
     return cdef.IsModelReady(model);
 }
 
+/// Unload model (including meshes) from memory (RAM and/or VRAM)
 pub fn unloadModel(model: Model) void {
     cdef.UnloadModel(model);
 }
 
+/// Compute model bounding box limits (considers all meshes)
 pub fn getModelBoundingBox(model: Model) BoundingBox {
     return cdef.GetModelBoundingBox(model);
 }
 
+/// Draw a model (with texture if set)
 pub fn drawModel(model: Model, position: Vector3, scale: f32, tint: Color) void {
     cdef.DrawModel(model, position, scale, tint);
 }
 
+/// Draw a model with extended parameters
 pub fn drawModelEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
     cdef.DrawModelEx(model, position, rotationAxis, rotationAngle, scale, tint);
 }
 
+/// Draw a model wires (with texture if set)
 pub fn drawModelWires(model: Model, position: Vector3, scale: f32, tint: Color) void {
     cdef.DrawModelWires(model, position, scale, tint);
 }
 
+/// Draw a model wires (with texture if set) with extended parameters
 pub fn drawModelWiresEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
     cdef.DrawModelWiresEx(model, position, rotationAxis, rotationAngle, scale, tint);
 }
 
+/// Draw bounding box (wires)
 pub fn drawBoundingBox(box: BoundingBox, color: Color) void {
     cdef.DrawBoundingBox(box, color);
 }
 
+/// Draw a billboard texture
 pub fn drawBillboard(camera: Camera, texture: Texture2D, position: Vector3, size: f32, tint: Color) void {
     cdef.DrawBillboard(camera, texture, position, size, tint);
 }
 
+/// Draw a billboard texture defined by source
 pub fn drawBillboardRec(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, size: Vector2, tint: Color) void {
     cdef.DrawBillboardRec(camera, texture, source, position, size, tint);
 }
 
+/// Draw a billboard texture defined by source and rotation
 pub fn drawBillboardPro(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawBillboardPro(camera, texture, source, position, up, size, origin, rotation, tint);
 }
 
+/// Upload mesh vertex data in GPU and provide VAO/VBO ids
 pub fn uploadMesh(mesh: *Mesh, dynamic: bool) void {
     cdef.UploadMesh(@as([*c]Mesh, @ptrCast(mesh)), dynamic);
 }
 
+/// Update mesh vertex data in GPU for a specific buffer index
 pub fn updateMeshBuffer(mesh: Mesh, index: i32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.UpdateMeshBuffer(mesh, @as(c_int, index), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
+/// Unload mesh data from CPU and GPU
 pub fn unloadMesh(mesh: Mesh) void {
     cdef.UnloadMesh(mesh);
 }
 
+/// Draw a 3d mesh with material and transform
 pub fn drawMesh(mesh: Mesh, material: Material, transform: Matrix) void {
     cdef.DrawMesh(mesh, material, transform);
 }
 
+/// Compute mesh bounding box limits
 pub fn getMeshBoundingBox(mesh: Mesh) BoundingBox {
     return cdef.GetMeshBoundingBox(mesh);
 }
 
+/// Compute mesh tangents
 pub fn genMeshTangents(mesh: *Mesh) void {
     cdef.GenMeshTangents(@as([*c]Mesh, @ptrCast(mesh)));
 }
 
+/// Export mesh data to file, returns true on success
 pub fn exportMesh(mesh: Mesh, fileName: [:0]const u8) bool {
     return cdef.ExportMesh(mesh, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Export mesh as code file (.h) defining multiple arrays of vertex attributes
 pub fn exportMeshAsCode(mesh: Mesh, fileName: [:0]const u8) bool {
     return cdef.ExportMeshAsCode(mesh, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Generate polygonal mesh
 pub fn genMeshPoly(sides: i32, radius: f32) Mesh {
     return cdef.GenMeshPoly(@as(c_int, sides), radius);
 }
 
+/// Generate plane mesh (with subdivisions)
 pub fn genMeshPlane(width: f32, length: f32, resX: i32, resZ: i32) Mesh {
     return cdef.GenMeshPlane(width, length, @as(c_int, resX), @as(c_int, resZ));
 }
 
+/// Generate cuboid mesh
 pub fn genMeshCube(width: f32, height: f32, length: f32) Mesh {
     return cdef.GenMeshCube(width, height, length);
 }
 
+/// Generate sphere mesh (standard sphere)
 pub fn genMeshSphere(radius: f32, rings: i32, slices: i32) Mesh {
     return cdef.GenMeshSphere(radius, @as(c_int, rings), @as(c_int, slices));
 }
 
+/// Generate half-sphere mesh (no bottom cap)
 pub fn genMeshHemiSphere(radius: f32, rings: i32, slices: i32) Mesh {
     return cdef.GenMeshHemiSphere(radius, @as(c_int, rings), @as(c_int, slices));
 }
 
+/// Generate cylinder mesh
 pub fn genMeshCylinder(radius: f32, height: f32, slices: i32) Mesh {
     return cdef.GenMeshCylinder(radius, height, @as(c_int, slices));
 }
 
+/// Generate cone/pyramid mesh
 pub fn genMeshCone(radius: f32, height: f32, slices: i32) Mesh {
     return cdef.GenMeshCone(radius, height, @as(c_int, slices));
 }
 
+/// Generate torus mesh
 pub fn genMeshTorus(radius: f32, size: f32, radSeg: i32, sides: i32) Mesh {
     return cdef.GenMeshTorus(radius, size, @as(c_int, radSeg), @as(c_int, sides));
 }
 
+/// Generate trefoil knot mesh
 pub fn genMeshKnot(radius: f32, size: f32, radSeg: i32, sides: i32) Mesh {
     return cdef.GenMeshKnot(radius, size, @as(c_int, radSeg), @as(c_int, sides));
 }
 
+/// Generate heightmap mesh from image data
 pub fn genMeshHeightmap(heightmap: Image, size: Vector3) Mesh {
     return cdef.GenMeshHeightmap(heightmap, size);
 }
 
+/// Generate cubes-based map mesh from image data
 pub fn genMeshCubicmap(cubicmap: Image, cubeSize: Vector3) Mesh {
     return cdef.GenMeshCubicmap(cubicmap, cubeSize);
 }
 
+/// Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
 pub fn loadMaterialDefault() Material {
     return cdef.LoadMaterialDefault();
 }
 
+/// Check if a material is ready
 pub fn isMaterialReady(material: Material) bool {
     return cdef.IsMaterialReady(material);
 }
 
+/// Unload material from GPU memory (VRAM)
 pub fn unloadMaterial(material: Material) void {
     cdef.UnloadMaterial(material);
 }
 
+/// Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
 pub fn setMaterialTexture(material: *Material, mapType: MaterialMapIndex, texture: Texture2D) void {
     cdef.SetMaterialTexture(@as([*c]Material, @ptrCast(material)), mapType, texture);
 }
 
+/// Set material for a mesh
 pub fn setModelMeshMaterial(model: *Model, meshId: i32, materialId: i32) void {
     cdef.SetModelMeshMaterial(@as([*c]Model, @ptrCast(model)), @as(c_int, meshId), @as(c_int, materialId));
 }
 
+/// Update model animation pose
 pub fn updateModelAnimation(model: Model, anim: ModelAnimation, frame: i32) void {
     cdef.UpdateModelAnimation(model, anim, @as(c_int, frame));
 }
 
+/// Unload animation data
 pub fn unloadModelAnimation(anim: ModelAnimation) void {
     cdef.UnloadModelAnimation(anim);
 }
 
+/// Check model animation skeleton match
 pub fn isModelAnimationValid(model: Model, anim: ModelAnimation) bool {
     return cdef.IsModelAnimationValid(model, anim);
 }
 
+/// Check collision between two spheres
 pub fn checkCollisionSpheres(center1: Vector3, radius1: f32, center2: Vector3, radius2: f32) bool {
     return cdef.CheckCollisionSpheres(center1, radius1, center2, radius2);
 }
 
+/// Check collision between two bounding boxes
 pub fn checkCollisionBoxes(box1: BoundingBox, box2: BoundingBox) bool {
     return cdef.CheckCollisionBoxes(box1, box2);
 }
 
+/// Check collision between box and sphere
 pub fn checkCollisionBoxSphere(box: BoundingBox, center: Vector3, radius: f32) bool {
     return cdef.CheckCollisionBoxSphere(box, center, radius);
 }
 
+/// Get collision info between ray and sphere
 pub fn getRayCollisionSphere(ray: Ray, center: Vector3, radius: f32) RayCollision {
     return cdef.GetRayCollisionSphere(ray, center, radius);
 }
 
+/// Get collision info between ray and box
 pub fn getRayCollisionBox(ray: Ray, box: BoundingBox) RayCollision {
     return cdef.GetRayCollisionBox(ray, box);
 }
 
+/// Get collision info between ray and mesh
 pub fn getRayCollisionMesh(ray: Ray, mesh: Mesh, transform: Matrix) RayCollision {
     return cdef.GetRayCollisionMesh(ray, mesh, transform);
 }
 
+/// Get collision info between ray and triangle
 pub fn getRayCollisionTriangle(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3) RayCollision {
     return cdef.GetRayCollisionTriangle(ray, p1, p2, p3);
 }
 
+/// Get collision info between ray and quad
 pub fn getRayCollisionQuad(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3, p4: Vector3) RayCollision {
     return cdef.GetRayCollisionQuad(ray, p1, p2, p3, p4);
 }
 
+/// Initialize audio device and context
 pub fn initAudioDevice() void {
     cdef.InitAudioDevice();
 }
 
+/// Close the audio device and context
 pub fn closeAudioDevice() void {
     cdef.CloseAudioDevice();
 }
 
+/// Check if audio device has been initialized successfully
 pub fn isAudioDeviceReady() bool {
     return cdef.IsAudioDeviceReady();
 }
 
+/// Set master volume (listener)
 pub fn setMasterVolume(volume: f32) void {
     cdef.SetMasterVolume(volume);
 }
 
+/// Get master volume (listener)
 pub fn getMasterVolume() f32 {
     return cdef.GetMasterVolume();
 }
 
+/// Load wave data from file
 pub fn loadWave(fileName: [:0]const u8) Wave {
     return cdef.LoadWave(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Checks if wave data is ready
 pub fn isWaveReady(wave: Wave) bool {
     return cdef.IsWaveReady(wave);
 }
 
+/// Load sound from file
 pub fn loadSound(fileName: [:0]const u8) Sound {
     return cdef.LoadSound(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load sound from wave data
 pub fn loadSoundFromWave(wave: Wave) Sound {
     return cdef.LoadSoundFromWave(wave);
 }
 
+/// Create a new sound that shares the same sample data as the source sound, does not own the sound data
 pub fn loadSoundAlias(source: Sound) Sound {
     return cdef.LoadSoundAlias(source);
 }
 
+/// Checks if a sound is ready
 pub fn isSoundReady(sound: Sound) bool {
     return cdef.IsSoundReady(sound);
 }
 
+/// Update sound buffer with new data
 pub fn updateSound(sound: Sound, data: *const anyopaque, sampleCount: i32) void {
     cdef.UpdateSound(sound, data, @as(c_int, sampleCount));
 }
 
+/// Unload wave data
 pub fn unloadWave(wave: Wave) void {
     cdef.UnloadWave(wave);
 }
 
+/// Unload sound
 pub fn unloadSound(sound: Sound) void {
     cdef.UnloadSound(sound);
 }
 
+/// Unload a sound alias (does not deallocate sample data)
 pub fn unloadSoundAlias(alias: Sound) void {
     cdef.UnloadSoundAlias(alias);
 }
 
+/// Export wave data to file, returns true on success
 pub fn exportWave(wave: Wave, fileName: [:0]const u8) bool {
     return cdef.ExportWave(wave, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Export wave sample data to code (.h), returns true on success
 pub fn exportWaveAsCode(wave: Wave, fileName: [:0]const u8) bool {
     return cdef.ExportWaveAsCode(wave, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Play a sound
 pub fn playSound(sound: Sound) void {
     cdef.PlaySound(sound);
 }
 
+/// Stop playing a sound
 pub fn stopSound(sound: Sound) void {
     cdef.StopSound(sound);
 }
 
+/// Pause a sound
 pub fn pauseSound(sound: Sound) void {
     cdef.PauseSound(sound);
 }
 
+/// Resume a paused sound
 pub fn resumeSound(sound: Sound) void {
     cdef.ResumeSound(sound);
 }
 
+/// Check if a sound is currently playing
 pub fn isSoundPlaying(sound: Sound) bool {
     return cdef.IsSoundPlaying(sound);
 }
 
+/// Set volume for a sound (1.0 is max level)
 pub fn setSoundVolume(sound: Sound, volume: f32) void {
     cdef.SetSoundVolume(sound, volume);
 }
 
+/// Set pitch for a sound (1.0 is base level)
 pub fn setSoundPitch(sound: Sound, pitch: f32) void {
     cdef.SetSoundPitch(sound, pitch);
 }
 
+/// Set pan for a sound (0.5 is center)
 pub fn setSoundPan(sound: Sound, pan: f32) void {
     cdef.SetSoundPan(sound, pan);
 }
 
+/// Copy a wave to a new wave
 pub fn waveCopy(wave: Wave) Wave {
     return cdef.WaveCopy(wave);
 }
 
+/// Crop a wave to defined frames range
 pub fn waveCrop(wave: *Wave, initFrame: i32, finalFrame: i32) void {
     cdef.WaveCrop(@as([*c]Wave, @ptrCast(wave)), @as(c_int, initFrame), @as(c_int, finalFrame));
 }
 
+/// Convert wave data to desired format
 pub fn waveFormat(wave: *Wave, sampleRate: i32, sampleSize: i32, channels: i32) void {
     cdef.WaveFormat(@as([*c]Wave, @ptrCast(wave)), @as(c_int, sampleRate), @as(c_int, sampleSize), @as(c_int, channels));
 }
 
+/// Unload samples data loaded with LoadWaveSamples()
 pub fn unloadWaveSamples(samples: []f32) void {
     cdef.UnloadWaveSamples(@as([*c]f32, @ptrCast(samples)));
 }
 
+/// Load music stream from file
 pub fn loadMusicStream(fileName: [:0]const u8) Music {
     return cdef.LoadMusicStream(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Checks if a music stream is ready
 pub fn isMusicReady(music: Music) bool {
     return cdef.IsMusicReady(music);
 }
 
+/// Unload music stream
 pub fn unloadMusicStream(music: Music) void {
     cdef.UnloadMusicStream(music);
 }
 
+/// Start music playing
 pub fn playMusicStream(music: Music) void {
     cdef.PlayMusicStream(music);
 }
 
+/// Check if music is playing
 pub fn isMusicStreamPlaying(music: Music) bool {
     return cdef.IsMusicStreamPlaying(music);
 }
 
+/// Updates buffers for music streaming
 pub fn updateMusicStream(music: Music) void {
     cdef.UpdateMusicStream(music);
 }
 
+/// Stop music playing
 pub fn stopMusicStream(music: Music) void {
     cdef.StopMusicStream(music);
 }
 
+/// Pause music playing
 pub fn pauseMusicStream(music: Music) void {
     cdef.PauseMusicStream(music);
 }
 
+/// Resume playing paused music
 pub fn resumeMusicStream(music: Music) void {
     cdef.ResumeMusicStream(music);
 }
 
+/// Seek music to a position (in seconds)
 pub fn seekMusicStream(music: Music, position: f32) void {
     cdef.SeekMusicStream(music, position);
 }
 
+/// Set volume for music (1.0 is max level)
 pub fn setMusicVolume(music: Music, volume: f32) void {
     cdef.SetMusicVolume(music, volume);
 }
 
+/// Set pitch for a music (1.0 is base level)
 pub fn setMusicPitch(music: Music, pitch: f32) void {
     cdef.SetMusicPitch(music, pitch);
 }
 
+/// Set pan for a music (0.5 is center)
 pub fn setMusicPan(music: Music, pan: f32) void {
     cdef.SetMusicPan(music, pan);
 }
 
+/// Get music time length (in seconds)
 pub fn getMusicTimeLength(music: Music) f32 {
     return cdef.GetMusicTimeLength(music);
 }
 
+/// Get current music time played (in seconds)
 pub fn getMusicTimePlayed(music: Music) f32 {
     return cdef.GetMusicTimePlayed(music);
 }
 
+/// Load audio stream (to stream raw audio pcm data)
 pub fn loadAudioStream(sampleRate: u32, sampleSize: u32, channels: u32) AudioStream {
     return cdef.LoadAudioStream(@as(c_uint, sampleRate), @as(c_uint, sampleSize), @as(c_uint, channels));
 }
 
+/// Checks if an audio stream is ready
 pub fn isAudioStreamReady(stream: AudioStream) bool {
     return cdef.IsAudioStreamReady(stream);
 }
 
+/// Unload audio stream and free memory
 pub fn unloadAudioStream(stream: AudioStream) void {
     cdef.UnloadAudioStream(stream);
 }
 
+/// Update audio stream buffers with data
 pub fn updateAudioStream(stream: AudioStream, data: *const anyopaque, frameCount: i32) void {
     cdef.UpdateAudioStream(stream, data, @as(c_int, frameCount));
 }
 
+/// Check if any audio stream buffers requires refill
 pub fn isAudioStreamProcessed(stream: AudioStream) bool {
     return cdef.IsAudioStreamProcessed(stream);
 }
 
+/// Play audio stream
 pub fn playAudioStream(stream: AudioStream) void {
     cdef.PlayAudioStream(stream);
 }
 
+/// Pause audio stream
 pub fn pauseAudioStream(stream: AudioStream) void {
     cdef.PauseAudioStream(stream);
 }
 
+/// Resume audio stream
 pub fn resumeAudioStream(stream: AudioStream) void {
     cdef.ResumeAudioStream(stream);
 }
 
+/// Check if audio stream is playing
 pub fn isAudioStreamPlaying(stream: AudioStream) bool {
     return cdef.IsAudioStreamPlaying(stream);
 }
 
+/// Stop audio stream
 pub fn stopAudioStream(stream: AudioStream) void {
     cdef.StopAudioStream(stream);
 }
 
+/// Set volume for audio stream (1.0 is max level)
 pub fn setAudioStreamVolume(stream: AudioStream, volume: f32) void {
     cdef.SetAudioStreamVolume(stream, volume);
 }
 
+/// Set pitch for audio stream (1.0 is base level)
 pub fn setAudioStreamPitch(stream: AudioStream, pitch: f32) void {
     cdef.SetAudioStreamPitch(stream, pitch);
 }
 
+/// Set pan for audio stream (0.5 is centered)
 pub fn setAudioStreamPan(stream: AudioStream, pan: f32) void {
     cdef.SetAudioStreamPan(stream, pan);
 }
 
+/// Default size for new audio streams
 pub fn setAudioStreamBufferSizeDefault(size: i32) void {
     cdef.SetAudioStreamBufferSizeDefault(@as(c_int, size));
 }
 
+/// Audio thread callback to request new data
 pub fn setAudioStreamCallback(stream: AudioStream, callback: AudioCallback) void {
     cdef.SetAudioStreamCallback(stream, callback);
 }
 
+/// Attach audio stream processor to stream, receives the samples as 'float'
 pub fn attachAudioStreamProcessor(stream: AudioStream, processor: AudioCallback) void {
     cdef.AttachAudioStreamProcessor(stream, processor);
 }
 
+/// Detach audio stream processor from stream
 pub fn detachAudioStreamProcessor(stream: AudioStream, processor: AudioCallback) void {
     cdef.DetachAudioStreamProcessor(stream, processor);
 }
 
+/// Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 pub fn attachAudioMixedProcessor(processor: AudioCallback) void {
     cdef.AttachAudioMixedProcessor(processor);
 }
 
+/// Detach audio stream processor from the entire audio pipeline
 pub fn detachAudioMixedProcessor(processor: AudioCallback) void {
     cdef.DetachAudioMixedProcessor(processor);
 }

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -2290,862 +2290,1077 @@ pub const mem = std.mem.Allocator{
     .vtable = &mem_vtable,
 };
 
+/// Initialize window and OpenGL context
 pub fn initWindow(width: i32, height: i32, title: [:0]const u8) void {
     cdef.InitWindow(@as(c_int, width), @as(c_int, height), @as([*c]const u8, @ptrCast(title)));
 }
 
+/// Close window and unload OpenGL context
 pub fn closeWindow() void {
     cdef.CloseWindow();
 }
 
+/// Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
 pub fn windowShouldClose() bool {
     return cdef.WindowShouldClose();
 }
 
+/// Check if window has been initialized successfully
 pub fn isWindowReady() bool {
     return cdef.IsWindowReady();
 }
 
+/// Check if window is currently fullscreen
 pub fn isWindowFullscreen() bool {
     return cdef.IsWindowFullscreen();
 }
 
+/// Check if window is currently hidden (only PLATFORM_DESKTOP)
 pub fn isWindowHidden() bool {
     return cdef.IsWindowHidden();
 }
 
+/// Check if window is currently minimized (only PLATFORM_DESKTOP)
 pub fn isWindowMinimized() bool {
     return cdef.IsWindowMinimized();
 }
 
+/// Check if window is currently maximized (only PLATFORM_DESKTOP)
 pub fn isWindowMaximized() bool {
     return cdef.IsWindowMaximized();
 }
 
+/// Check if window is currently focused (only PLATFORM_DESKTOP)
 pub fn isWindowFocused() bool {
     return cdef.IsWindowFocused();
 }
 
+/// Check if window has been resized last frame
 pub fn isWindowResized() bool {
     return cdef.IsWindowResized();
 }
 
+/// Check if one specific window flag is enabled
 pub fn isWindowState(flag: ConfigFlags) bool {
     return cdef.IsWindowState(flag);
 }
 
+/// Set window configuration state using flags (only PLATFORM_DESKTOP)
 pub fn setWindowState(flags: ConfigFlags) void {
     cdef.SetWindowState(flags);
 }
 
+/// Clear window configuration state flags
 pub fn clearWindowState(flags: ConfigFlags) void {
     cdef.ClearWindowState(flags);
 }
 
+/// Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
 pub fn toggleFullscreen() void {
     cdef.ToggleFullscreen();
 }
 
+/// Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
 pub fn toggleBorderlessWindowed() void {
     cdef.ToggleBorderlessWindowed();
 }
 
+/// Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 pub fn maximizeWindow() void {
     cdef.MaximizeWindow();
 }
 
+/// Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
 pub fn minimizeWindow() void {
     cdef.MinimizeWindow();
 }
 
+/// Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
 pub fn restoreWindow() void {
     cdef.RestoreWindow();
 }
 
+/// Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
 pub fn setWindowIcon(image: Image) void {
     cdef.SetWindowIcon(image);
 }
 
+/// Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
 pub fn setWindowTitle(title: [:0]const u8) void {
     cdef.SetWindowTitle(@as([*c]const u8, @ptrCast(title)));
 }
 
+/// Set window position on screen (only PLATFORM_DESKTOP)
 pub fn setWindowPosition(x: i32, y: i32) void {
     cdef.SetWindowPosition(@as(c_int, x), @as(c_int, y));
 }
 
+/// Set monitor for the current window
 pub fn setWindowMonitor(monitor: i32) void {
     cdef.SetWindowMonitor(@as(c_int, monitor));
 }
 
+/// Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 pub fn setWindowMinSize(width: i32, height: i32) void {
     cdef.SetWindowMinSize(@as(c_int, width), @as(c_int, height));
 }
 
+/// Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
 pub fn setWindowMaxSize(width: i32, height: i32) void {
     cdef.SetWindowMaxSize(@as(c_int, width), @as(c_int, height));
 }
 
+/// Set window dimensions
 pub fn setWindowSize(width: i32, height: i32) void {
     cdef.SetWindowSize(@as(c_int, width), @as(c_int, height));
 }
 
+/// Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
 pub fn setWindowOpacity(opacity: f32) void {
     cdef.SetWindowOpacity(opacity);
 }
 
+/// Set window focused (only PLATFORM_DESKTOP)
 pub fn setWindowFocused() void {
     cdef.SetWindowFocused();
 }
 
+/// Get native window handle
 pub fn getWindowHandle() *anyopaque {
     return cdef.GetWindowHandle();
 }
 
+/// Get current screen width
 pub fn getScreenWidth() i32 {
     return @as(i32, cdef.GetScreenWidth());
 }
 
+/// Get current screen height
 pub fn getScreenHeight() i32 {
     return @as(i32, cdef.GetScreenHeight());
 }
 
+/// Get current render width (it considers HiDPI)
 pub fn getRenderWidth() i32 {
     return @as(i32, cdef.GetRenderWidth());
 }
 
+/// Get current render height (it considers HiDPI)
 pub fn getRenderHeight() i32 {
     return @as(i32, cdef.GetRenderHeight());
 }
 
+/// Get number of connected monitors
 pub fn getMonitorCount() i32 {
     return @as(i32, cdef.GetMonitorCount());
 }
 
+/// Get current connected monitor
 pub fn getCurrentMonitor() i32 {
     return @as(i32, cdef.GetCurrentMonitor());
 }
 
+/// Get specified monitor position
 pub fn getMonitorPosition(monitor: i32) Vector2 {
     return cdef.GetMonitorPosition(@as(c_int, monitor));
 }
 
+/// Get specified monitor width (current video mode used by monitor)
 pub fn getMonitorWidth(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorWidth(@as(c_int, monitor)));
 }
 
+/// Get specified monitor height (current video mode used by monitor)
 pub fn getMonitorHeight(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorHeight(@as(c_int, monitor)));
 }
 
+/// Get specified monitor physical width in millimetres
 pub fn getMonitorPhysicalWidth(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorPhysicalWidth(@as(c_int, monitor)));
 }
 
+/// Get specified monitor physical height in millimetres
 pub fn getMonitorPhysicalHeight(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorPhysicalHeight(@as(c_int, monitor)));
 }
 
+/// Get specified monitor refresh rate
 pub fn getMonitorRefreshRate(monitor: i32) i32 {
     return @as(i32, cdef.GetMonitorRefreshRate(@as(c_int, monitor)));
 }
 
+/// Get window position XY on monitor
 pub fn getWindowPosition() Vector2 {
     return cdef.GetWindowPosition();
 }
 
+/// Get window scale DPI factor
 pub fn getWindowScaleDPI() Vector2 {
     return cdef.GetWindowScaleDPI();
 }
 
+/// Get the human-readable, UTF-8 encoded name of the specified monitor
 pub fn getMonitorName(monitor: i32) [:0]const u8 {
     return std.mem.span(cdef.GetMonitorName(@as(c_int, monitor)));
 }
 
+/// Set clipboard text content
 pub fn setClipboardText(text: [:0]const u8) void {
     cdef.SetClipboardText(@as([*c]const u8, @ptrCast(text)));
 }
 
+/// Get clipboard text content
 pub fn getClipboardText() [:0]const u8 {
     return std.mem.span(cdef.GetClipboardText());
 }
 
+/// Enable waiting for events on EndDrawing(), no automatic event polling
 pub fn enableEventWaiting() void {
     cdef.EnableEventWaiting();
 }
 
+/// Disable waiting for events on EndDrawing(), automatic events polling
 pub fn disableEventWaiting() void {
     cdef.DisableEventWaiting();
 }
 
+/// Shows cursor
 pub fn showCursor() void {
     cdef.ShowCursor();
 }
 
+/// Hides cursor
 pub fn hideCursor() void {
     cdef.HideCursor();
 }
 
+/// Check if cursor is not visible
 pub fn isCursorHidden() bool {
     return cdef.IsCursorHidden();
 }
 
+/// Enables cursor (unlock cursor)
 pub fn enableCursor() void {
     cdef.EnableCursor();
 }
 
+/// Disables cursor (lock cursor)
 pub fn disableCursor() void {
     cdef.DisableCursor();
 }
 
+/// Check if cursor is on the screen
 pub fn isCursorOnScreen() bool {
     return cdef.IsCursorOnScreen();
 }
 
+/// Set background color (framebuffer clear color)
 pub fn clearBackground(color: Color) void {
     cdef.ClearBackground(color);
 }
 
+/// Setup canvas (framebuffer) to start drawing
 pub fn beginDrawing() void {
     cdef.BeginDrawing();
 }
 
+/// End canvas drawing and swap buffers (double buffering)
 pub fn endDrawing() void {
     cdef.EndDrawing();
 }
 
+/// Begin 2D mode with custom camera (2D)
 pub fn beginMode2D(camera: Camera2D) void {
     cdef.BeginMode2D(camera);
 }
 
+/// Ends 2D mode with custom camera
 pub fn endMode2D() void {
     cdef.EndMode2D();
 }
 
+/// Begin 3D mode with custom camera (3D)
 pub fn beginMode3D(camera: Camera3D) void {
     cdef.BeginMode3D(camera);
 }
 
+/// Ends 3D mode and returns to default 2D orthographic mode
 pub fn endMode3D() void {
     cdef.EndMode3D();
 }
 
+/// Begin drawing to render texture
 pub fn beginTextureMode(target: RenderTexture2D) void {
     cdef.BeginTextureMode(target);
 }
 
+/// Ends drawing to render texture
 pub fn endTextureMode() void {
     cdef.EndTextureMode();
 }
 
+/// Begin custom shader drawing
 pub fn beginShaderMode(shader: Shader) void {
     cdef.BeginShaderMode(shader);
 }
 
+/// End custom shader drawing (use default shader)
 pub fn endShaderMode() void {
     cdef.EndShaderMode();
 }
 
+/// Begin blending mode (alpha, additive, multiplied, subtract, custom)
 pub fn beginBlendMode(mode: BlendMode) void {
     cdef.BeginBlendMode(mode);
 }
 
+/// End blending mode (reset to default: alpha blending)
 pub fn endBlendMode() void {
     cdef.EndBlendMode();
 }
 
+/// Begin scissor mode (define screen area for following drawing)
 pub fn beginScissorMode(x: i32, y: i32, width: i32, height: i32) void {
     cdef.BeginScissorMode(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
+/// End scissor mode
 pub fn endScissorMode() void {
     cdef.EndScissorMode();
 }
 
+/// Begin stereo rendering (requires VR simulator)
 pub fn beginVrStereoMode(config: VrStereoConfig) void {
     cdef.BeginVrStereoMode(config);
 }
 
+/// End stereo rendering (requires VR simulator)
 pub fn endVrStereoMode() void {
     cdef.EndVrStereoMode();
 }
 
+/// Load VR stereo config for VR simulator device parameters
 pub fn loadVrStereoConfig(device: VrDeviceInfo) VrStereoConfig {
     return cdef.LoadVrStereoConfig(device);
 }
 
+/// Unload VR stereo config
 pub fn unloadVrStereoConfig(config: VrStereoConfig) void {
     cdef.UnloadVrStereoConfig(config);
 }
 
+/// Check if a shader is ready
 pub fn isShaderReady(shader: Shader) bool {
     return cdef.IsShaderReady(shader);
 }
 
+/// Get shader uniform location
 pub fn getShaderLocation(shader: Shader, uniformName: [:0]const u8) i32 {
     return @as(i32, cdef.GetShaderLocation(shader, @as([*c]const u8, @ptrCast(uniformName))));
 }
 
+/// Get shader attribute location
 pub fn getShaderLocationAttrib(shader: Shader, attribName: [:0]const u8) i32 {
     return @as(i32, cdef.GetShaderLocationAttrib(shader, @as([*c]const u8, @ptrCast(attribName))));
 }
 
+/// Set shader uniform value
 pub fn setShaderValue(shader: Shader, locIndex: i32, value: *const anyopaque, uniformType: ShaderUniformDataType) void {
     cdef.SetShaderValue(shader, @as(c_int, locIndex), value, uniformType);
 }
 
+/// Set shader uniform value vector
 pub fn setShaderValueV(shader: Shader, locIndex: i32, value: *const anyopaque, uniformType: ShaderUniformDataType, count: i32) void {
     cdef.SetShaderValueV(shader, @as(c_int, locIndex), value, uniformType, @as(c_int, count));
 }
 
+/// Set shader uniform value (matrix 4x4)
 pub fn setShaderValueMatrix(shader: Shader, locIndex: i32, mat: Matrix) void {
     cdef.SetShaderValueMatrix(shader, @as(c_int, locIndex), mat);
 }
 
+/// Set shader uniform value for texture (sampler2d)
 pub fn setShaderValueTexture(shader: Shader, locIndex: i32, texture: Texture2D) void {
     cdef.SetShaderValueTexture(shader, @as(c_int, locIndex), texture);
 }
 
+/// Unload shader from GPU memory (VRAM)
 pub fn unloadShader(shader: Shader) void {
     cdef.UnloadShader(shader);
 }
 
+/// Get a ray trace from screen position (i.e mouse)
 pub fn getScreenToWorldRay(position: Vector2, camera: Camera) Ray {
     return cdef.GetScreenToWorldRay(position, camera);
 }
 
+/// Get a ray trace from screen position (i.e mouse) in a viewport
 pub fn getScreenToWorldRayEx(position: Vector2, camera: Camera, width: i32, height: i32) Ray {
     return cdef.GetScreenToWorldRayEx(position, camera, @as(c_int, width), @as(c_int, height));
 }
 
+/// Get the screen space position for a 3d world space position
 pub fn getWorldToScreen(position: Vector3, camera: Camera) Vector2 {
     return cdef.GetWorldToScreen(position, camera);
 }
 
+/// Get size position for a 3d world space position
 pub fn getWorldToScreenEx(position: Vector3, camera: Camera, width: i32, height: i32) Vector2 {
     return cdef.GetWorldToScreenEx(position, camera, @as(c_int, width), @as(c_int, height));
 }
 
+/// Get the screen space position for a 2d camera world space position
 pub fn getWorldToScreen2D(position: Vector2, camera: Camera2D) Vector2 {
     return cdef.GetWorldToScreen2D(position, camera);
 }
 
+/// Get the world space position for a 2d camera screen space position
 pub fn getScreenToWorld2D(position: Vector2, camera: Camera2D) Vector2 {
     return cdef.GetScreenToWorld2D(position, camera);
 }
 
+/// Get camera transform matrix (view matrix)
 pub fn getCameraMatrix(camera: Camera) Matrix {
     return cdef.GetCameraMatrix(camera);
 }
 
+/// Get camera 2d transform matrix
 pub fn getCameraMatrix2D(camera: Camera2D) Matrix {
     return cdef.GetCameraMatrix2D(camera);
 }
 
+/// Set target FPS (maximum)
 pub fn setTargetFPS(fps: i32) void {
     cdef.SetTargetFPS(@as(c_int, fps));
 }
 
+/// Get time in seconds for last frame drawn (delta time)
 pub fn getFrameTime() f32 {
     return cdef.GetFrameTime();
 }
 
+/// Get elapsed time in seconds since InitWindow()
 pub fn getTime() f64 {
     return cdef.GetTime();
 }
 
+/// Get current FPS
 pub fn getFPS() i32 {
     return @as(i32, cdef.GetFPS());
 }
 
+/// Swap back buffer with front buffer (screen drawing)
 pub fn swapScreenBuffer() void {
     cdef.SwapScreenBuffer();
 }
 
+/// Register all input events
 pub fn pollInputEvents() void {
     cdef.PollInputEvents();
 }
 
+/// Wait for some time (halt program execution)
 pub fn waitTime(seconds: f64) void {
     cdef.WaitTime(seconds);
 }
 
+/// Set the seed for the random number generator
 pub fn setRandomSeed(seed: u32) void {
     cdef.SetRandomSeed(@as(c_uint, seed));
 }
 
+/// Get a random value between min and max (both included)
 pub fn getRandomValue(min: i32, max: i32) i32 {
     return @as(i32, cdef.GetRandomValue(@as(c_int, min), @as(c_int, max)));
 }
 
+/// Unload random values sequence
 pub fn unloadRandomSequence(sequence: []i32) void {
     cdef.UnloadRandomSequence(@as([*c]c_int, @ptrCast(sequence)));
 }
 
+/// Takes a screenshot of current screen (filename extension defines format)
 pub fn takeScreenshot(fileName: [:0]const u8) void {
     cdef.TakeScreenshot(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Setup init configuration flags (view FLAGS)
 pub fn setConfigFlags(flags: ConfigFlags) void {
     cdef.SetConfigFlags(flags);
 }
 
+/// Open URL with default system browser (if available)
 pub fn openURL(url: [:0]const u8) void {
     cdef.OpenURL(@as([*c]const u8, @ptrCast(url)));
 }
 
+/// Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 pub fn traceLog(logLevel: TraceLogLevel, text: [:0]const u8) void {
     cdef.TraceLog(logLevel, @as([*c]const u8, @ptrCast(text)));
 }
 
+/// Set the current threshold (minimum) log level
 pub fn setTraceLogLevel(logLevel: TraceLogLevel) void {
     cdef.SetTraceLogLevel(logLevel);
 }
 
+/// Internal memory allocator
 pub fn memAlloc(size: u32) *anyopaque {
     return cdef.MemAlloc(@as(c_uint, size));
 }
 
+/// Internal memory reallocator
 pub fn memRealloc(ptr: *anyopaque, size: u32) *anyopaque {
     return cdef.MemRealloc(ptr, @as(c_uint, size));
 }
 
+/// Internal memory free
 pub fn memFree(ptr: *anyopaque) void {
     cdef.MemFree(ptr);
 }
 
+/// Set custom file binary data loader
 pub fn setLoadFileDataCallback(callback: LoadFileDataCallback) void {
     cdef.SetLoadFileDataCallback(callback);
 }
 
+/// Set custom file binary data saver
 pub fn setSaveFileDataCallback(callback: SaveFileDataCallback) void {
     cdef.SetSaveFileDataCallback(callback);
 }
 
+/// Set custom file text data loader
 pub fn setLoadFileTextCallback(callback: LoadFileTextCallback) void {
     cdef.SetLoadFileTextCallback(callback);
 }
 
+/// Set custom file text data saver
 pub fn setSaveFileTextCallback(callback: SaveFileTextCallback) void {
     cdef.SetSaveFileTextCallback(callback);
 }
 
+/// Unload file data allocated by LoadFileData()
 pub fn unloadFileData(data: []u8) void {
     cdef.UnloadFileData(@as([*c]u8, @ptrCast(data)));
 }
 
+/// Load text data from file (read), returns a '\0' terminated string
 pub fn loadFileText(fileName: [:0]const u8) [:0]u8 {
     return std.mem.span(cdef.LoadFileText(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Unload file text data allocated by LoadFileText()
 pub fn unloadFileText(text: [:0]u8) void {
     cdef.UnloadFileText(@as([*c]u8, @ptrCast(text)));
 }
 
+/// Save text data to file (write), string must be '\0' terminated, returns true on success
 pub fn saveFileText(fileName: [:0]const u8, text: [:0]u8) bool {
     return cdef.SaveFileText(@as([*c]const u8, @ptrCast(fileName)), @as([*c]u8, @ptrCast(text)));
 }
 
+/// Check if file exists
 pub fn fileExists(fileName: [:0]const u8) bool {
     return cdef.FileExists(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Check if a directory path exists
 pub fn directoryExists(dirPath: [:0]const u8) bool {
     return cdef.DirectoryExists(@as([*c]const u8, @ptrCast(dirPath)));
 }
 
+/// Check file extension (including point: .png, .wav)
 pub fn isFileExtension(fileName: [:0]const u8, ext: [:0]const u8) bool {
     return cdef.IsFileExtension(@as([*c]const u8, @ptrCast(fileName)), @as([*c]const u8, @ptrCast(ext)));
 }
 
+/// Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
 pub fn getFileLength(fileName: [:0]const u8) i32 {
     return @as(i32, cdef.GetFileLength(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Get pointer to extension for a filename string (includes dot: '.png')
 pub fn getFileExtension(fileName: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileExtension(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Get pointer to filename for a path string
 pub fn getFileName(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileName(@as([*c]const u8, @ptrCast(filePath))));
 }
 
+/// Get filename string without extension (uses static string)
 pub fn getFileNameWithoutExt(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetFileNameWithoutExt(@as([*c]const u8, @ptrCast(filePath))));
 }
 
+/// Get full path for a given fileName with path (uses static string)
 pub fn getDirectoryPath(filePath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetDirectoryPath(@as([*c]const u8, @ptrCast(filePath))));
 }
 
+/// Get previous directory path for a given path (uses static string)
 pub fn getPrevDirectoryPath(dirPath: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.GetPrevDirectoryPath(@as([*c]const u8, @ptrCast(dirPath))));
 }
 
+/// Get current working directory (uses static string)
 pub fn getWorkingDirectory() [:0]const u8 {
     return std.mem.span(cdef.GetWorkingDirectory());
 }
 
+/// Get the directory of the running application (uses static string)
 pub fn getApplicationDirectory() [:0]const u8 {
     return std.mem.span(cdef.GetApplicationDirectory());
 }
 
+/// Change working directory, return true on success
 pub fn changeDirectory(dir: [:0]const u8) bool {
     return cdef.ChangeDirectory(@as([*c]const u8, @ptrCast(dir)));
 }
 
+/// Check if a given path is a file or a directory
 pub fn isPathFile(path: [:0]const u8) bool {
     return cdef.IsPathFile(@as([*c]const u8, @ptrCast(path)));
 }
 
+/// Check if fileName is valid for the platform/OS
 pub fn isFileNameValid(fileName: [:0]const u8) bool {
     return cdef.IsFileNameValid(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load directory filepaths
 pub fn loadDirectoryFiles(dirPath: [:0]const u8) FilePathList {
     return cdef.LoadDirectoryFiles(@as([*c]const u8, @ptrCast(dirPath)));
 }
 
+/// Load directory filepaths with extension filtering and recursive directory scan
 pub fn loadDirectoryFilesEx(basePath: [:0]const u8, filter: [:0]const u8, scanSubdirs: bool) FilePathList {
     return cdef.LoadDirectoryFilesEx(@as([*c]const u8, @ptrCast(basePath)), @as([*c]const u8, @ptrCast(filter)), scanSubdirs);
 }
 
+/// Unload filepaths
 pub fn unloadDirectoryFiles(files: FilePathList) void {
     cdef.UnloadDirectoryFiles(files);
 }
 
+/// Check if a file has been dropped into window
 pub fn isFileDropped() bool {
     return cdef.IsFileDropped();
 }
 
+/// Load dropped filepaths
 pub fn loadDroppedFiles() FilePathList {
     return cdef.LoadDroppedFiles();
 }
 
+/// Unload dropped filepaths
 pub fn unloadDroppedFiles(files: FilePathList) void {
     cdef.UnloadDroppedFiles(files);
 }
 
+/// Get file modification time (last write time)
 pub fn getFileModTime(fileName: [:0]const u8) i64 {
     return @as(i64, cdef.GetFileModTime(@as([*c]const u8, @ptrCast(fileName))));
 }
 
+/// Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
 pub fn loadAutomationEventList(fileName: [:0]const u8) AutomationEventList {
     return cdef.LoadAutomationEventList(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Unload automation events list from file
 pub fn unloadAutomationEventList(list: AutomationEventList) void {
     cdef.UnloadAutomationEventList(list);
 }
 
+/// Export automation events list as text file
 pub fn exportAutomationEventList(list: AutomationEventList, fileName: [:0]const u8) bool {
     return cdef.ExportAutomationEventList(list, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Set automation event list to record to
 pub fn setAutomationEventList(list: *AutomationEventList) void {
     cdef.SetAutomationEventList(@as([*c]AutomationEventList, @ptrCast(list)));
 }
 
+/// Set automation event internal base frame to start recording
 pub fn setAutomationEventBaseFrame(frame: i32) void {
     cdef.SetAutomationEventBaseFrame(@as(c_int, frame));
 }
 
+/// Start recording automation events (AutomationEventList must be set)
 pub fn startAutomationEventRecording() void {
     cdef.StartAutomationEventRecording();
 }
 
+/// Stop recording automation events
 pub fn stopAutomationEventRecording() void {
     cdef.StopAutomationEventRecording();
 }
 
+/// Play a recorded automation event
 pub fn playAutomationEvent(event: AutomationEvent) void {
     cdef.PlayAutomationEvent(event);
 }
 
+/// Check if a key has been pressed once
 pub fn isKeyPressed(key: KeyboardKey) bool {
     return cdef.IsKeyPressed(key);
 }
 
+/// Check if a key has been pressed again (Only PLATFORM_DESKTOP)
 pub fn isKeyPressedRepeat(key: KeyboardKey) bool {
     return cdef.IsKeyPressedRepeat(key);
 }
 
+/// Check if a key is being pressed
 pub fn isKeyDown(key: KeyboardKey) bool {
     return cdef.IsKeyDown(key);
 }
 
+/// Check if a key has been released once
 pub fn isKeyReleased(key: KeyboardKey) bool {
     return cdef.IsKeyReleased(key);
 }
 
+/// Check if a key is NOT being pressed
 pub fn isKeyUp(key: KeyboardKey) bool {
     return cdef.IsKeyUp(key);
 }
 
+/// Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 pub fn getKeyPressed() KeyboardKey {
     return cdef.GetKeyPressed();
 }
 
+/// Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 pub fn getCharPressed() i32 {
     return @as(i32, cdef.GetCharPressed());
 }
 
+/// Set a custom key to exit program (default is ESC)
 pub fn setExitKey(key: KeyboardKey) void {
     cdef.SetExitKey(key);
 }
 
+/// Check if a gamepad is available
 pub fn isGamepadAvailable(gamepad: i32) bool {
     return cdef.IsGamepadAvailable(@as(c_int, gamepad));
 }
 
+/// Get gamepad internal name id
 pub fn getGamepadName(gamepad: i32) [:0]const u8 {
     return std.mem.span(cdef.GetGamepadName(@as(c_int, gamepad)));
 }
 
+/// Check if a gamepad button has been pressed once
 pub fn isGamepadButtonPressed(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonPressed(@as(c_int, gamepad), button);
 }
 
+/// Check if a gamepad button is being pressed
 pub fn isGamepadButtonDown(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonDown(@as(c_int, gamepad), button);
 }
 
+/// Check if a gamepad button has been released once
 pub fn isGamepadButtonReleased(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonReleased(@as(c_int, gamepad), button);
 }
 
+/// Check if a gamepad button is NOT being pressed
 pub fn isGamepadButtonUp(gamepad: i32, button: GamepadButton) bool {
     return cdef.IsGamepadButtonUp(@as(c_int, gamepad), button);
 }
 
+/// Get the last gamepad button pressed
 pub fn getGamepadButtonPressed() GamepadButton {
     return cdef.GetGamepadButtonPressed();
 }
 
+/// Get gamepad axis count for a gamepad
 pub fn getGamepadAxisCount(gamepad: i32) i32 {
     return @as(i32, cdef.GetGamepadAxisCount(@as(c_int, gamepad)));
 }
 
+/// Get axis movement value for a gamepad axis
 pub fn getGamepadAxisMovement(gamepad: i32, axis: i32) f32 {
     return cdef.GetGamepadAxisMovement(@as(c_int, gamepad), @as(c_int, axis));
 }
 
+/// Set internal gamepad mappings (SDL_GameControllerDB)
 pub fn setGamepadMappings(mappings: [:0]const u8) i32 {
     return @as(i32, cdef.SetGamepadMappings(@as([*c]const u8, @ptrCast(mappings))));
 }
 
+/// Set gamepad vibration for both motors
 pub fn setGamepadVibration(gamepad: i32, leftMotor: f32, rightMotor: f32) void {
     cdef.SetGamepadVibration(@as(c_int, gamepad), leftMotor, rightMotor);
 }
 
+/// Check if a mouse button has been pressed once
 pub fn isMouseButtonPressed(button: MouseButton) bool {
     return cdef.IsMouseButtonPressed(button);
 }
 
+/// Check if a mouse button is being pressed
 pub fn isMouseButtonDown(button: MouseButton) bool {
     return cdef.IsMouseButtonDown(button);
 }
 
+/// Check if a mouse button has been released once
 pub fn isMouseButtonReleased(button: MouseButton) bool {
     return cdef.IsMouseButtonReleased(button);
 }
 
+/// Check if a mouse button is NOT being pressed
 pub fn isMouseButtonUp(button: MouseButton) bool {
     return cdef.IsMouseButtonUp(button);
 }
 
+/// Get mouse position X
 pub fn getMouseX() i32 {
     return @as(i32, cdef.GetMouseX());
 }
 
+/// Get mouse position Y
 pub fn getMouseY() i32 {
     return @as(i32, cdef.GetMouseY());
 }
 
+/// Get mouse position XY
 pub fn getMousePosition() Vector2 {
     return cdef.GetMousePosition();
 }
 
+/// Get mouse delta between frames
 pub fn getMouseDelta() Vector2 {
     return cdef.GetMouseDelta();
 }
 
+/// Set mouse position XY
 pub fn setMousePosition(x: i32, y: i32) void {
     cdef.SetMousePosition(@as(c_int, x), @as(c_int, y));
 }
 
+/// Set mouse offset
 pub fn setMouseOffset(offsetX: i32, offsetY: i32) void {
     cdef.SetMouseOffset(@as(c_int, offsetX), @as(c_int, offsetY));
 }
 
+/// Set mouse scaling
 pub fn setMouseScale(scaleX: f32, scaleY: f32) void {
     cdef.SetMouseScale(scaleX, scaleY);
 }
 
+/// Get mouse wheel movement for X or Y, whichever is larger
 pub fn getMouseWheelMove() f32 {
     return cdef.GetMouseWheelMove();
 }
 
+/// Get mouse wheel movement for both X and Y
 pub fn getMouseWheelMoveV() Vector2 {
     return cdef.GetMouseWheelMoveV();
 }
 
+/// Set mouse cursor
 pub fn setMouseCursor(cursor: i32) void {
     cdef.SetMouseCursor(@as(c_int, cursor));
 }
 
+/// Get touch position X for touch point 0 (relative to screen size)
 pub fn getTouchX() i32 {
     return @as(i32, cdef.GetTouchX());
 }
 
+/// Get touch position Y for touch point 0 (relative to screen size)
 pub fn getTouchY() i32 {
     return @as(i32, cdef.GetTouchY());
 }
 
+/// Get touch position XY for a touch point index (relative to screen size)
 pub fn getTouchPosition(index: i32) Vector2 {
     return cdef.GetTouchPosition(@as(c_int, index));
 }
 
+/// Get touch point identifier for given index
 pub fn getTouchPointId(index: i32) i32 {
     return @as(i32, cdef.GetTouchPointId(@as(c_int, index)));
 }
 
+/// Get number of touch points
 pub fn getTouchPointCount() i32 {
     return @as(i32, cdef.GetTouchPointCount());
 }
 
+/// Enable a set of gestures using flags
 pub fn setGesturesEnabled(flags: Gesture) void {
     cdef.SetGesturesEnabled(flags);
 }
 
+/// Check if a gesture have been detected
 pub fn isGestureDetected(gesture: Gesture) bool {
     return cdef.IsGestureDetected(gesture);
 }
 
+/// Get latest detected gesture
 pub fn getGestureDetected() Gesture {
     return cdef.GetGestureDetected();
 }
 
+/// Get gesture hold time in milliseconds
 pub fn getGestureHoldDuration() f32 {
     return cdef.GetGestureHoldDuration();
 }
 
+/// Get gesture drag vector
 pub fn getGestureDragVector() Vector2 {
     return cdef.GetGestureDragVector();
 }
 
+/// Get gesture drag angle
 pub fn getGestureDragAngle() f32 {
     return cdef.GetGestureDragAngle();
 }
 
+/// Get gesture pinch delta
 pub fn getGesturePinchVector() Vector2 {
     return cdef.GetGesturePinchVector();
 }
 
+/// Get gesture pinch angle
 pub fn getGesturePinchAngle() f32 {
     return cdef.GetGesturePinchAngle();
 }
 
+/// Update camera position for selected mode
 pub fn updateCamera(camera: *Camera, mode: CameraMode) void {
     cdef.UpdateCamera(@as([*c]Camera, @ptrCast(camera)), mode);
 }
 
+/// Update camera movement/rotation
 pub fn updateCameraPro(camera: *Camera, movement: Vector3, rotation: Vector3, zoom: f32) void {
     cdef.UpdateCameraPro(@as([*c]Camera, @ptrCast(camera)), movement, rotation, zoom);
 }
 
+/// Set texture and rectangle to be used on shapes drawing
 pub fn setShapesTexture(texture: Texture2D, source: Rectangle) void {
     cdef.SetShapesTexture(texture, source);
 }
 
+/// Get texture that is used for shapes drawing
 pub fn getShapesTexture() Texture2D {
     return cdef.GetShapesTexture();
 }
 
+/// Get texture source rectangle that is used for shapes drawing
 pub fn getShapesTextureRectangle() Rectangle {
     return cdef.GetShapesTextureRectangle();
 }
 
+/// Draw a pixel
 pub fn drawPixel(posX: i32, posY: i32, color: Color) void {
     cdef.DrawPixel(@as(c_int, posX), @as(c_int, posY), color);
 }
 
+/// Draw a pixel (Vector version)
 pub fn drawPixelV(position: Vector2, color: Color) void {
     cdef.DrawPixelV(position, color);
 }
 
+/// Draw a line
 pub fn drawLine(startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
     cdef.DrawLine(@as(c_int, startPosX), @as(c_int, startPosY), @as(c_int, endPosX), @as(c_int, endPosY), color);
 }
 
+/// Draw a line (using gl lines)
 pub fn drawLineV(startPos: Vector2, endPos: Vector2, color: Color) void {
     cdef.DrawLineV(startPos, endPos, color);
 }
 
+/// Draw a line (using triangles/quads)
 pub fn drawLineEx(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) void {
     cdef.DrawLineEx(startPos, endPos, thick, color);
 }
 
+/// Draw line segment cubic-bezier in-out interpolation
 pub fn drawLineBezier(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) void {
     cdef.DrawLineBezier(startPos, endPos, thick, color);
 }
 
+/// Draw a color-filled circle
 pub fn drawCircle(centerX: i32, centerY: i32, radius: f32, color: Color) void {
     cdef.DrawCircle(@as(c_int, centerX), @as(c_int, centerY), radius, color);
 }
 
+/// Draw a piece of a circle
 pub fn drawCircleSector(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawCircleSector(center, radius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw circle sector outline
 pub fn drawCircleSectorLines(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawCircleSectorLines(center, radius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw a gradient-filled circle
 pub fn drawCircleGradient(centerX: i32, centerY: i32, radius: f32, color1: Color, color2: Color) void {
     cdef.DrawCircleGradient(@as(c_int, centerX), @as(c_int, centerY), radius, color1, color2);
 }
 
+/// Draw a color-filled circle (Vector version)
 pub fn drawCircleV(center: Vector2, radius: f32, color: Color) void {
     cdef.DrawCircleV(center, radius, color);
 }
 
+/// Draw circle outline
 pub fn drawCircleLines(centerX: i32, centerY: i32, radius: f32, color: Color) void {
     cdef.DrawCircleLines(@as(c_int, centerX), @as(c_int, centerY), radius, color);
 }
 
+/// Draw circle outline (Vector version)
 pub fn drawCircleLinesV(center: Vector2, radius: f32, color: Color) void {
     cdef.DrawCircleLinesV(center, radius, color);
 }
 
+/// Draw ellipse
 pub fn drawEllipse(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) void {
     cdef.DrawEllipse(@as(c_int, centerX), @as(c_int, centerY), radiusH, radiusV, color);
 }
 
+/// Draw ellipse outline
 pub fn drawEllipseLines(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) void {
     cdef.DrawEllipseLines(@as(c_int, centerX), @as(c_int, centerY), radiusH, radiusV, color);
 }
 
+/// Draw ring
 pub fn drawRing(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawRing(center, innerRadius, outerRadius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw ring outline
 pub fn drawRingLines(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) void {
     cdef.DrawRingLines(center, innerRadius, outerRadius, startAngle, endAngle, @as(c_int, segments), color);
 }
 
+/// Draw a color-filled rectangle
 pub fn drawRectangle(posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.DrawRectangle(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
+/// Draw a color-filled rectangle (Vector version)
 pub fn drawRectangleV(position: Vector2, size: Vector2, color: Color) void {
     cdef.DrawRectangleV(position, size, color);
 }
 
+/// Draw a color-filled rectangle
 pub fn drawRectangleRec(rec: Rectangle, color: Color) void {
     cdef.DrawRectangleRec(rec, color);
 }
 
+/// Draw a color-filled rectangle with pro parameters
 pub fn drawRectanglePro(rec: Rectangle, origin: Vector2, rotation: f32, color: Color) void {
     cdef.DrawRectanglePro(rec, origin, rotation, color);
 }
@@ -3160,1242 +3375,1552 @@ pub fn drawRectangleGradientH(posX: i32, posY: i32, width: i32, height: i32, col
     cdef.DrawRectangleGradientH(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color1, color2);
 }
 
+/// Draw a gradient-filled rectangle with custom vertex colors
 pub fn drawRectangleGradientEx(rec: Rectangle, col1: Color, col2: Color, col3: Color, col4: Color) void {
     cdef.DrawRectangleGradientEx(rec, col1, col2, col3, col4);
 }
 
+/// Draw rectangle outline
 pub fn drawRectangleLines(posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.DrawRectangleLines(@as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
+/// Draw rectangle outline with extended parameters
 pub fn drawRectangleLinesEx(rec: Rectangle, lineThick: f32, color: Color) void {
     cdef.DrawRectangleLinesEx(rec, lineThick, color);
 }
 
+/// Draw rectangle with rounded edges
 pub fn drawRectangleRounded(rec: Rectangle, roundness: f32, segments: i32, color: Color) void {
     cdef.DrawRectangleRounded(rec, roundness, @as(c_int, segments), color);
 }
 
+/// Draw rectangle lines with rounded edges
 pub fn drawRectangleRoundedLines(rec: Rectangle, roundness: f32, segments: i32, color: Color) void {
     cdef.DrawRectangleRoundedLines(rec, roundness, @as(c_int, segments), color);
 }
 
+/// Draw rectangle with rounded edges outline
 pub fn drawRectangleRoundedLinesEx(rec: Rectangle, roundness: f32, segments: i32, lineThick: f32, color: Color) void {
     cdef.DrawRectangleRoundedLinesEx(rec, roundness, @as(c_int, segments), lineThick, color);
 }
 
+/// Draw a color-filled triangle (vertex in counter-clockwise order!)
 pub fn drawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) void {
     cdef.DrawTriangle(v1, v2, v3, color);
 }
 
+/// Draw triangle outline (vertex in counter-clockwise order!)
 pub fn drawTriangleLines(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) void {
     cdef.DrawTriangleLines(v1, v2, v3, color);
 }
 
+/// Draw a regular polygon (Vector version)
 pub fn drawPoly(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) void {
     cdef.DrawPoly(center, @as(c_int, sides), radius, rotation, color);
 }
 
+/// Draw a polygon outline of n sides
 pub fn drawPolyLines(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) void {
     cdef.DrawPolyLines(center, @as(c_int, sides), radius, rotation, color);
 }
 
+/// Draw a polygon outline of n sides with extended parameters
 pub fn drawPolyLinesEx(center: Vector2, sides: i32, radius: f32, rotation: f32, lineThick: f32, color: Color) void {
     cdef.DrawPolyLinesEx(center, @as(c_int, sides), radius, rotation, lineThick, color);
 }
 
+/// Draw spline: Linear, minimum 2 points
 pub fn drawSplineLinear(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineLinear(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: B-Spline, minimum 4 points
 pub fn drawSplineBasis(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBasis(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: Catmull-Rom, minimum 4 points
 pub fn drawSplineCatmullRom(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineCatmullRom(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
 pub fn drawSplineBezierQuadratic(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBezierQuadratic(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
 pub fn drawSplineBezierCubic(points: []Vector2, pointCount: i32, thick: f32, color: Color) void {
     cdef.DrawSplineBezierCubic(@as([*c]Vector2, @ptrCast(points)), @as(c_int, pointCount), thick, color);
 }
 
+/// Draw spline segment: Linear, 2 points
 pub fn drawSplineSegmentLinear(p1: Vector2, p2: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentLinear(p1, p2, thick, color);
 }
 
+/// Draw spline segment: B-Spline, 4 points
 pub fn drawSplineSegmentBasis(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBasis(p1, p2, p3, p4, thick, color);
 }
 
+/// Draw spline segment: Catmull-Rom, 4 points
 pub fn drawSplineSegmentCatmullRom(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentCatmullRom(p1, p2, p3, p4, thick, color);
 }
 
+/// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
 pub fn drawSplineSegmentBezierQuadratic(p1: Vector2, c2: Vector2, p3: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBezierQuadratic(p1, c2, p3, thick, color);
 }
 
+/// Draw spline segment: Cubic Bezier, 2 points, 2 control points
 pub fn drawSplineSegmentBezierCubic(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: f32, color: Color) void {
     cdef.DrawSplineSegmentBezierCubic(p1, c2, c3, p4, thick, color);
 }
 
+/// Get (evaluate) spline point: Linear
 pub fn getSplinePointLinear(startPos: Vector2, endPos: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointLinear(startPos, endPos, t);
 }
 
+/// Get (evaluate) spline point: B-Spline
 pub fn getSplinePointBasis(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBasis(p1, p2, p3, p4, t);
 }
 
+/// Get (evaluate) spline point: Catmull-Rom
 pub fn getSplinePointCatmullRom(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointCatmullRom(p1, p2, p3, p4, t);
 }
 
+/// Get (evaluate) spline point: Quadratic Bezier
 pub fn getSplinePointBezierQuad(p1: Vector2, c2: Vector2, p3: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBezierQuad(p1, c2, p3, t);
 }
 
+/// Get (evaluate) spline point: Cubic Bezier
 pub fn getSplinePointBezierCubic(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: f32) Vector2 {
     return cdef.GetSplinePointBezierCubic(p1, c2, c3, p4, t);
 }
 
+/// Check collision between two rectangles
 pub fn checkCollisionRecs(rec1: Rectangle, rec2: Rectangle) bool {
     return cdef.CheckCollisionRecs(rec1, rec2);
 }
 
+/// Check collision between two circles
 pub fn checkCollisionCircles(center1: Vector2, radius1: f32, center2: Vector2, radius2: f32) bool {
     return cdef.CheckCollisionCircles(center1, radius1, center2, radius2);
 }
 
+/// Check collision between circle and rectangle
 pub fn checkCollisionCircleRec(center: Vector2, radius: f32, rec: Rectangle) bool {
     return cdef.CheckCollisionCircleRec(center, radius, rec);
 }
 
+/// Check if point is inside rectangle
 pub fn checkCollisionPointRec(point: Vector2, rec: Rectangle) bool {
     return cdef.CheckCollisionPointRec(point, rec);
 }
 
+/// Check if point is inside circle
 pub fn checkCollisionPointCircle(point: Vector2, center: Vector2, radius: f32) bool {
     return cdef.CheckCollisionPointCircle(point, center, radius);
 }
 
+/// Check if point is inside a triangle
 pub fn checkCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) bool {
     return cdef.CheckCollisionPointTriangle(point, p1, p2, p3);
 }
 
+/// Check the collision between two lines defined by two points each, returns collision point by reference
 pub fn checkCollisionLines(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: *Vector2) bool {
     return cdef.CheckCollisionLines(startPos1, endPos1, startPos2, endPos2, @as([*c]Vector2, @ptrCast(collisionPoint)));
 }
 
+/// Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
 pub fn checkCollisionPointLine(point: Vector2, p1: Vector2, p2: Vector2, threshold: i32) bool {
     return cdef.CheckCollisionPointLine(point, p1, p2, @as(c_int, threshold));
 }
 
+/// Check if circle collides with a line created betweeen two points [p1] and [p2]
 pub fn checkCollisionCircleLine(center: Vector2, radius: f32, p1: Vector2, p2: Vector2) bool {
     return cdef.CheckCollisionCircleLine(center, radius, p1, p2);
 }
 
+/// Get collision rectangle for two rectangles collision
 pub fn getCollisionRec(rec1: Rectangle, rec2: Rectangle) Rectangle {
     return cdef.GetCollisionRec(rec1, rec2);
 }
 
+/// Load image from file into CPU memory (RAM)
 pub fn loadImage(fileName: [:0]const u8) Image {
     return cdef.LoadImage(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load image from RAW file data
 pub fn loadImageRaw(fileName: [:0]const u8, width: i32, height: i32, format: PixelFormat, headerSize: i32) Image {
     return cdef.LoadImageRaw(@as([*c]const u8, @ptrCast(fileName)), @as(c_int, width), @as(c_int, height), format, @as(c_int, headerSize));
 }
 
+/// Load image from SVG file data or string with specified size
 pub fn loadImageSvg(fileNameOrString: [:0]const u8, width: i32, height: i32) Image {
     return cdef.LoadImageSvg(@as([*c]const u8, @ptrCast(fileNameOrString)), @as(c_int, width), @as(c_int, height));
 }
 
+/// Load image sequence from file (frames appended to image.data)
 pub fn loadImageAnim(fileName: [:0]const u8, frames: *i32) Image {
     return cdef.LoadImageAnim(@as([*c]const u8, @ptrCast(fileName)), @as([*c]c_int, @ptrCast(frames)));
 }
 
+/// Load image from GPU texture data
 pub fn loadImageFromTexture(texture: Texture2D) Image {
     return cdef.LoadImageFromTexture(texture);
 }
 
+/// Load image from screen buffer and (screenshot)
 pub fn loadImageFromScreen() Image {
     return cdef.LoadImageFromScreen();
 }
 
+/// Check if an image is ready
 pub fn isImageReady(image: Image) bool {
     return cdef.IsImageReady(image);
 }
 
+/// Unload image from CPU memory (RAM)
 pub fn unloadImage(image: Image) void {
     cdef.UnloadImage(image);
 }
 
+/// Export image data to file, returns true on success
 pub fn exportImage(image: Image, fileName: [:0]const u8) bool {
     return cdef.ExportImage(image, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Export image to memory buffer
 pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) [:0]u8 {
     return std.mem.span(cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize))));
 }
 
+/// Export image as code file defining an array of bytes, returns true on success
 pub fn exportImageAsCode(image: Image, fileName: [:0]const u8) bool {
     return cdef.ExportImageAsCode(image, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Generate image: plain color
 pub fn genImageColor(width: i32, height: i32, color: Color) Image {
     return cdef.GenImageColor(@as(c_int, width), @as(c_int, height), color);
 }
 
+/// Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
 pub fn genImageGradientLinear(width: i32, height: i32, direction: i32, start: Color, end: Color) Image {
     return cdef.GenImageGradientLinear(@as(c_int, width), @as(c_int, height), @as(c_int, direction), start, end);
 }
 
+/// Generate image: radial gradient
 pub fn genImageGradientRadial(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
     return cdef.GenImageGradientRadial(@as(c_int, width), @as(c_int, height), density, inner, outer);
 }
 
+/// Generate image: square gradient
 pub fn genImageGradientSquare(width: i32, height: i32, density: f32, inner: Color, outer: Color) Image {
     return cdef.GenImageGradientSquare(@as(c_int, width), @as(c_int, height), density, inner, outer);
 }
 
+/// Generate image: checked
 pub fn genImageChecked(width: i32, height: i32, checksX: i32, checksY: i32, col1: Color, col2: Color) Image {
     return cdef.GenImageChecked(@as(c_int, width), @as(c_int, height), @as(c_int, checksX), @as(c_int, checksY), col1, col2);
 }
 
+/// Generate image: white noise
 pub fn genImageWhiteNoise(width: i32, height: i32, factor: f32) Image {
     return cdef.GenImageWhiteNoise(@as(c_int, width), @as(c_int, height), factor);
 }
 
+/// Generate image: perlin noise
 pub fn genImagePerlinNoise(width: i32, height: i32, offsetX: i32, offsetY: i32, scale: f32) Image {
     return cdef.GenImagePerlinNoise(@as(c_int, width), @as(c_int, height), @as(c_int, offsetX), @as(c_int, offsetY), scale);
 }
 
+/// Generate image: cellular algorithm, bigger tileSize means bigger cells
 pub fn genImageCellular(width: i32, height: i32, tileSize: i32) Image {
     return cdef.GenImageCellular(@as(c_int, width), @as(c_int, height), @as(c_int, tileSize));
 }
 
+/// Generate image: grayscale image from text data
 pub fn genImageText(width: i32, height: i32, text: [:0]const u8) Image {
     return cdef.GenImageText(@as(c_int, width), @as(c_int, height), @as([*c]const u8, @ptrCast(text)));
 }
 
+/// Create an image duplicate (useful for transformations)
 pub fn imageCopy(image: Image) Image {
     return cdef.ImageCopy(image);
 }
 
+/// Create an image from another image piece
 pub fn imageFromImage(image: Image, rec: Rectangle) Image {
     return cdef.ImageFromImage(image, rec);
 }
 
+/// Create an image from text (default font)
 pub fn imageText(text: [:0]const u8, fontSize: i32, color: Color) Image {
     return cdef.ImageText(@as([*c]const u8, @ptrCast(text)), @as(c_int, fontSize), color);
 }
 
+/// Create an image from text (custom sprite font)
 pub fn imageTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32, tint: Color) Image {
     return cdef.ImageTextEx(font, @as([*c]const u8, @ptrCast(text)), fontSize, spacing, tint);
 }
 
+/// Convert image data to desired format
 pub fn imageFormat(image: *Image, newFormat: PixelFormat) void {
     cdef.ImageFormat(@as([*c]Image, @ptrCast(image)), newFormat);
 }
 
+/// Convert image to POT (power-of-two)
 pub fn imageToPOT(image: *Image, fill: Color) void {
     cdef.ImageToPOT(@as([*c]Image, @ptrCast(image)), fill);
 }
 
+/// Crop an image to a defined rectangle
 pub fn imageCrop(image: *Image, crop: Rectangle) void {
     cdef.ImageCrop(@as([*c]Image, @ptrCast(image)), crop);
 }
 
+/// Crop image depending on alpha value
 pub fn imageAlphaCrop(image: *Image, threshold: f32) void {
     cdef.ImageAlphaCrop(@as([*c]Image, @ptrCast(image)), threshold);
 }
 
+/// Clear alpha channel to desired color
 pub fn imageAlphaClear(image: *Image, color: Color, threshold: f32) void {
     cdef.ImageAlphaClear(@as([*c]Image, @ptrCast(image)), color, threshold);
 }
 
+/// Apply alpha mask to image
 pub fn imageAlphaMask(image: *Image, alphaMask: Image) void {
     cdef.ImageAlphaMask(@as([*c]Image, @ptrCast(image)), alphaMask);
 }
 
+/// Premultiply alpha channel
 pub fn imageAlphaPremultiply(image: *Image) void {
     cdef.ImageAlphaPremultiply(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Apply Gaussian blur using a box blur approximation
 pub fn imageBlurGaussian(image: *Image, blurSize: i32) void {
     cdef.ImageBlurGaussian(@as([*c]Image, @ptrCast(image)), @as(c_int, blurSize));
 }
 
+/// Apply Custom Square image convolution kernel
 pub fn imageKernelConvolution(image: *Image, kernel: []f32, kernelSize: i32) void {
     cdef.ImageKernelConvolution(@as([*c]Image, @ptrCast(image)), @as([*c]f32, @ptrCast(kernel)), @as(c_int, kernelSize));
 }
 
+/// Resize image (Bicubic scaling algorithm)
 pub fn imageResize(image: *Image, newWidth: i32, newHeight: i32) void {
     cdef.ImageResize(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight));
 }
 
+/// Resize image (Nearest-Neighbor scaling algorithm)
 pub fn imageResizeNN(image: *Image, newWidth: i32, newHeight: i32) void {
     cdef.ImageResizeNN(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight));
 }
 
+/// Resize canvas and fill with color
 pub fn imageResizeCanvas(image: *Image, newWidth: i32, newHeight: i32, offsetX: i32, offsetY: i32, fill: Color) void {
     cdef.ImageResizeCanvas(@as([*c]Image, @ptrCast(image)), @as(c_int, newWidth), @as(c_int, newHeight), @as(c_int, offsetX), @as(c_int, offsetY), fill);
 }
 
+/// Compute all mipmap levels for a provided image
 pub fn imageMipmaps(image: *Image) void {
     cdef.ImageMipmaps(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
 pub fn imageDither(image: *Image, rBpp: i32, gBpp: i32, bBpp: i32, aBpp: i32) void {
     cdef.ImageDither(@as([*c]Image, @ptrCast(image)), @as(c_int, rBpp), @as(c_int, gBpp), @as(c_int, bBpp), @as(c_int, aBpp));
 }
 
+/// Flip image vertically
 pub fn imageFlipVertical(image: *Image) void {
     cdef.ImageFlipVertical(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Flip image horizontally
 pub fn imageFlipHorizontal(image: *Image) void {
     cdef.ImageFlipHorizontal(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Rotate image by input angle in degrees (-359 to 359)
 pub fn imageRotate(image: *Image, degrees: i32) void {
     cdef.ImageRotate(@as([*c]Image, @ptrCast(image)), @as(c_int, degrees));
 }
 
+/// Rotate image clockwise 90deg
 pub fn imageRotateCW(image: *Image) void {
     cdef.ImageRotateCW(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Rotate image counter-clockwise 90deg
 pub fn imageRotateCCW(image: *Image) void {
     cdef.ImageRotateCCW(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Modify image color: tint
 pub fn imageColorTint(image: *Image, color: Color) void {
     cdef.ImageColorTint(@as([*c]Image, @ptrCast(image)), color);
 }
 
+/// Modify image color: invert
 pub fn imageColorInvert(image: *Image) void {
     cdef.ImageColorInvert(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Modify image color: grayscale
 pub fn imageColorGrayscale(image: *Image) void {
     cdef.ImageColorGrayscale(@as([*c]Image, @ptrCast(image)));
 }
 
+/// Modify image color: contrast (-100 to 100)
 pub fn imageColorContrast(image: *Image, contrast: f32) void {
     cdef.ImageColorContrast(@as([*c]Image, @ptrCast(image)), contrast);
 }
 
+/// Modify image color: brightness (-255 to 255)
 pub fn imageColorBrightness(image: *Image, brightness: i32) void {
     cdef.ImageColorBrightness(@as([*c]Image, @ptrCast(image)), @as(c_int, brightness));
 }
 
+/// Modify image color: replace color
 pub fn imageColorReplace(image: *Image, color: Color, replace: Color) void {
     cdef.ImageColorReplace(@as([*c]Image, @ptrCast(image)), color, replace);
 }
 
+/// Unload color data loaded with LoadImageColors()
 pub fn unloadImageColors(colors: []Color) void {
     cdef.UnloadImageColors(@as([*c]Color, @ptrCast(colors)));
 }
 
+/// Unload colors palette loaded with LoadImagePalette()
 pub fn unloadImagePalette(colors: []Color) void {
     cdef.UnloadImagePalette(@as([*c]Color, @ptrCast(colors)));
 }
 
+/// Get image alpha border rectangle
 pub fn getImageAlphaBorder(image: Image, threshold: f32) Rectangle {
     return cdef.GetImageAlphaBorder(image, threshold);
 }
 
+/// Get image pixel color at (x, y) position
 pub fn getImageColor(image: Image, x: i32, y: i32) Color {
     return cdef.GetImageColor(image, @as(c_int, x), @as(c_int, y));
 }
 
+/// Clear image background with given color
 pub fn imageClearBackground(dst: *Image, color: Color) void {
     cdef.ImageClearBackground(@as([*c]Image, @ptrCast(dst)), color);
 }
 
+/// Draw pixel within an image
 pub fn imageDrawPixel(dst: *Image, posX: i32, posY: i32, color: Color) void {
     cdef.ImageDrawPixel(@as([*c]Image, @ptrCast(dst)), @as(c_int, posX), @as(c_int, posY), color);
 }
 
+/// Draw pixel within an image (Vector version)
 pub fn imageDrawPixelV(dst: *Image, position: Vector2, color: Color) void {
     cdef.ImageDrawPixelV(@as([*c]Image, @ptrCast(dst)), position, color);
 }
 
+/// Draw line within an image
 pub fn imageDrawLine(dst: *Image, startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) void {
     cdef.ImageDrawLine(@as([*c]Image, @ptrCast(dst)), @as(c_int, startPosX), @as(c_int, startPosY), @as(c_int, endPosX), @as(c_int, endPosY), color);
 }
 
+/// Draw line within an image (Vector version)
 pub fn imageDrawLineV(dst: *Image, start: Vector2, end: Vector2, color: Color) void {
     cdef.ImageDrawLineV(@as([*c]Image, @ptrCast(dst)), start, end, color);
 }
 
+/// Draw a filled circle within an image
 pub fn imageDrawCircle(dst: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
     cdef.ImageDrawCircle(@as([*c]Image, @ptrCast(dst)), @as(c_int, centerX), @as(c_int, centerY), @as(c_int, radius), color);
 }
 
+/// Draw a filled circle within an image (Vector version)
 pub fn imageDrawCircleV(dst: *Image, center: Vector2, radius: i32, color: Color) void {
     cdef.ImageDrawCircleV(@as([*c]Image, @ptrCast(dst)), center, @as(c_int, radius), color);
 }
 
+/// Draw circle outline within an image
 pub fn imageDrawCircleLines(dst: *Image, centerX: i32, centerY: i32, radius: i32, color: Color) void {
     cdef.ImageDrawCircleLines(@as([*c]Image, @ptrCast(dst)), @as(c_int, centerX), @as(c_int, centerY), @as(c_int, radius), color);
 }
 
+/// Draw circle outline within an image (Vector version)
 pub fn imageDrawCircleLinesV(dst: *Image, center: Vector2, radius: i32, color: Color) void {
     cdef.ImageDrawCircleLinesV(@as([*c]Image, @ptrCast(dst)), center, @as(c_int, radius), color);
 }
 
+/// Draw rectangle within an image
 pub fn imageDrawRectangle(dst: *Image, posX: i32, posY: i32, width: i32, height: i32, color: Color) void {
     cdef.ImageDrawRectangle(@as([*c]Image, @ptrCast(dst)), @as(c_int, posX), @as(c_int, posY), @as(c_int, width), @as(c_int, height), color);
 }
 
+/// Draw rectangle within an image (Vector version)
 pub fn imageDrawRectangleV(dst: *Image, position: Vector2, size: Vector2, color: Color) void {
     cdef.ImageDrawRectangleV(@as([*c]Image, @ptrCast(dst)), position, size, color);
 }
 
+/// Draw rectangle within an image
 pub fn imageDrawRectangleRec(dst: *Image, rec: Rectangle, color: Color) void {
     cdef.ImageDrawRectangleRec(@as([*c]Image, @ptrCast(dst)), rec, color);
 }
 
+/// Draw rectangle lines within an image
 pub fn imageDrawRectangleLines(dst: *Image, rec: Rectangle, thick: i32, color: Color) void {
     cdef.ImageDrawRectangleLines(@as([*c]Image, @ptrCast(dst)), rec, @as(c_int, thick), color);
 }
 
+/// Draw a source image within a destination image (tint applied to source)
 pub fn imageDraw(dst: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color) void {
     cdef.ImageDraw(@as([*c]Image, @ptrCast(dst)), src, srcRec, dstRec, tint);
 }
 
+/// Draw text (using default font) within an image (destination)
 pub fn imageDrawText(dst: *Image, text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
     cdef.ImageDrawText(@as([*c]Image, @ptrCast(dst)), @as([*c]const u8, @ptrCast(text)), @as(c_int, posX), @as(c_int, posY), @as(c_int, fontSize), color);
 }
 
+/// Draw text (custom sprite font) within an image (destination)
 pub fn imageDrawTextEx(dst: *Image, font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.ImageDrawTextEx(@as([*c]Image, @ptrCast(dst)), font, @as([*c]const u8, @ptrCast(text)), position, fontSize, spacing, tint);
 }
 
+/// Load texture from file into GPU memory (VRAM)
 pub fn loadTexture(fileName: [:0]const u8) Texture2D {
     return cdef.LoadTexture(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load texture from image data
 pub fn loadTextureFromImage(image: Image) Texture2D {
     return cdef.LoadTextureFromImage(image);
 }
 
+/// Load cubemap from image, multiple image cubemap layouts supported
 pub fn loadTextureCubemap(image: Image, layout: CubemapLayout) TextureCubemap {
     return cdef.LoadTextureCubemap(image, layout);
 }
 
+/// Load texture for rendering (framebuffer)
 pub fn loadRenderTexture(width: i32, height: i32) RenderTexture2D {
     return cdef.LoadRenderTexture(@as(c_int, width), @as(c_int, height));
 }
 
+/// Check if a texture is ready
 pub fn isTextureReady(texture: Texture2D) bool {
     return cdef.IsTextureReady(texture);
 }
 
+/// Unload texture from GPU memory (VRAM)
 pub fn unloadTexture(texture: Texture2D) void {
     cdef.UnloadTexture(texture);
 }
 
+/// Check if a render texture is ready
 pub fn isRenderTextureReady(target: RenderTexture2D) bool {
     return cdef.IsRenderTextureReady(target);
 }
 
+/// Unload render texture from GPU memory (VRAM)
 pub fn unloadRenderTexture(target: RenderTexture2D) void {
     cdef.UnloadRenderTexture(target);
 }
 
+/// Update GPU texture with new data
 pub fn updateTexture(texture: Texture2D, pixels: *const anyopaque) void {
     cdef.UpdateTexture(texture, pixels);
 }
 
+/// Update GPU texture rectangle with new data
 pub fn updateTextureRec(texture: Texture2D, rec: Rectangle, pixels: *const anyopaque) void {
     cdef.UpdateTextureRec(texture, rec, pixels);
 }
 
+/// Generate GPU mipmaps for a texture
 pub fn genTextureMipmaps(texture: *Texture2D) void {
     cdef.GenTextureMipmaps(@as([*c]Texture2D, @ptrCast(texture)));
 }
 
+/// Set texture scaling filter mode
 pub fn setTextureFilter(texture: Texture2D, filter: TextureFilter) void {
     cdef.SetTextureFilter(texture, filter);
 }
 
+/// Set texture wrapping mode
 pub fn setTextureWrap(texture: Texture2D, wrap: i32) void {
     cdef.SetTextureWrap(texture, @as(c_int, wrap));
 }
 
+/// Draw a Texture2D
 pub fn drawTexture(texture: Texture2D, posX: i32, posY: i32, tint: Color) void {
     cdef.DrawTexture(texture, @as(c_int, posX), @as(c_int, posY), tint);
 }
 
+/// Draw a Texture2D with position defined as Vector2
 pub fn drawTextureV(texture: Texture2D, position: Vector2, tint: Color) void {
     cdef.DrawTextureV(texture, position, tint);
 }
 
+/// Draw a Texture2D with extended parameters
 pub fn drawTextureEx(texture: Texture2D, position: Vector2, rotation: f32, scale: f32, tint: Color) void {
     cdef.DrawTextureEx(texture, position, rotation, scale, tint);
 }
 
+/// Draw a part of a texture defined by a rectangle
 pub fn drawTextureRec(texture: Texture2D, source: Rectangle, position: Vector2, tint: Color) void {
     cdef.DrawTextureRec(texture, source, position, tint);
 }
 
+/// Draw a part of a texture defined by a rectangle with 'pro' parameters
 pub fn drawTexturePro(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawTexturePro(texture, source, dest, origin, rotation, tint);
 }
 
+/// Draws a texture (or part of it) that stretches or shrinks nicely
 pub fn drawTextureNPatch(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawTextureNPatch(texture, nPatchInfo, dest, origin, rotation, tint);
 }
 
+/// Check if two colors are equal
 pub fn colorIsEqual(col1: Color, col2: Color) bool {
     return cdef.ColorIsEqual(col1, col2);
 }
 
+/// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn fade(color: Color, alpha: f32) Color {
     return cdef.Fade(color, alpha);
 }
 
+/// Get hexadecimal value for a Color (0xRRGGBBAA)
 pub fn colorToInt(color: Color) i32 {
     return @as(i32, cdef.ColorToInt(color));
 }
 
+/// Get Color normalized as float [0..1]
 pub fn colorNormalize(color: Color) Vector4 {
     return cdef.ColorNormalize(color);
 }
 
+/// Get Color from normalized values [0..1]
 pub fn colorFromNormalized(normalized: Vector4) Color {
     return cdef.ColorFromNormalized(normalized);
 }
 
+/// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
 pub fn colorToHSV(color: Color) Vector3 {
     return cdef.ColorToHSV(color);
 }
 
+/// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
 pub fn colorFromHSV(hue: f32, saturation: f32, value: f32) Color {
     return cdef.ColorFromHSV(hue, saturation, value);
 }
 
+/// Get color multiplied with another color
 pub fn colorTint(color: Color, tint: Color) Color {
     return cdef.ColorTint(color, tint);
 }
 
+/// Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
 pub fn colorBrightness(color: Color, factor: f32) Color {
     return cdef.ColorBrightness(color, factor);
 }
 
+/// Get color with contrast correction, contrast values between -1.0f and 1.0f
 pub fn colorContrast(color: Color, contrast: f32) Color {
     return cdef.ColorContrast(color, contrast);
 }
 
+/// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn colorAlpha(color: Color, alpha: f32) Color {
     return cdef.ColorAlpha(color, alpha);
 }
 
+/// Get src alpha-blended into dst color with tint
 pub fn colorAlphaBlend(dst: Color, src: Color, tint: Color) Color {
     return cdef.ColorAlphaBlend(dst, src, tint);
 }
 
+/// Get Color structure from hexadecimal value
 pub fn getColor(hexValue: u32) Color {
     return cdef.GetColor(@as(c_uint, hexValue));
 }
 
+/// Get Color from a source pixel pointer of certain format
 pub fn getPixelColor(srcPtr: *anyopaque, format: PixelFormat) Color {
     return cdef.GetPixelColor(srcPtr, format);
 }
 
+/// Set color formatted into destination pixel pointer
 pub fn setPixelColor(dstPtr: *anyopaque, color: Color, format: PixelFormat) void {
     cdef.SetPixelColor(dstPtr, color, format);
 }
 
+/// Get pixel data size in bytes for certain format
 pub fn getPixelDataSize(width: i32, height: i32, format: PixelFormat) i32 {
     return @as(i32, cdef.GetPixelDataSize(@as(c_int, width), @as(c_int, height), format));
 }
 
+/// Get the default Font
 pub fn getFontDefault() Font {
     return cdef.GetFontDefault();
 }
 
+/// Load font from file into GPU memory (VRAM)
 pub fn loadFont(fileName: [:0]const u8) Font {
     return cdef.LoadFont(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load font from Image (XNA style)
 pub fn loadFontFromImage(image: Image, key: Color, firstChar: i32) Font {
     return cdef.LoadFontFromImage(image, key, @as(c_int, firstChar));
 }
 
+/// Check if a font is ready
 pub fn isFontReady(font: Font) bool {
     return cdef.IsFontReady(font);
 }
 
+/// Unload font from GPU memory (VRAM)
 pub fn unloadFont(font: Font) void {
     cdef.UnloadFont(font);
 }
 
+/// Export font as code file, returns true on success
 pub fn exportFontAsCode(font: Font, fileName: [:0]const u8) bool {
     return cdef.ExportFontAsCode(font, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Draw current FPS
 pub fn drawFPS(posX: i32, posY: i32) void {
     cdef.DrawFPS(@as(c_int, posX), @as(c_int, posY));
 }
 
+/// Draw text (using default font)
 pub fn drawText(text: [:0]const u8, posX: i32, posY: i32, fontSize: i32, color: Color) void {
     cdef.DrawText(@as([*c]const u8, @ptrCast(text)), @as(c_int, posX), @as(c_int, posY), @as(c_int, fontSize), color);
 }
 
+/// Draw text using font and additional parameters
 pub fn drawTextEx(font: Font, text: [:0]const u8, position: Vector2, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.DrawTextEx(font, @as([*c]const u8, @ptrCast(text)), position, fontSize, spacing, tint);
 }
 
+/// Draw text using Font and pro parameters (rotation)
 pub fn drawTextPro(font: Font, text: [:0]const u8, position: Vector2, origin: Vector2, rotation: f32, fontSize: f32, spacing: f32, tint: Color) void {
     cdef.DrawTextPro(font, @as([*c]const u8, @ptrCast(text)), position, origin, rotation, fontSize, spacing, tint);
 }
 
+/// Draw one character (codepoint)
 pub fn drawTextCodepoint(font: Font, codepoint: i32, position: Vector2, fontSize: f32, tint: Color) void {
     cdef.DrawTextCodepoint(font, @as(c_int, codepoint), position, fontSize, tint);
 }
 
+/// Set vertical line spacing when drawing with line-breaks
 pub fn setTextLineSpacing(spacing: i32) void {
     cdef.SetTextLineSpacing(@as(c_int, spacing));
 }
 
+/// Measure string width for default font
 pub fn measureText(text: [:0]const u8, fontSize: i32) i32 {
     return @as(i32, cdef.MeasureText(@as([*c]const u8, @ptrCast(text)), @as(c_int, fontSize)));
 }
 
+/// Measure string size for Font
 pub fn measureTextEx(font: Font, text: [:0]const u8, fontSize: f32, spacing: f32) Vector2 {
     return cdef.MeasureTextEx(font, @as([*c]const u8, @ptrCast(text)), fontSize, spacing);
 }
 
+/// Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphIndex(font: Font, codepoint: i32) i32 {
     return @as(i32, cdef.GetGlyphIndex(font, @as(c_int, codepoint)));
 }
 
+/// Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphInfo(font: Font, codepoint: i32) GlyphInfo {
     return cdef.GetGlyphInfo(font, @as(c_int, codepoint));
 }
 
+/// Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
 pub fn getGlyphAtlasRec(font: Font, codepoint: i32) Rectangle {
     return cdef.GetGlyphAtlasRec(font, @as(c_int, codepoint));
 }
 
+/// Unload UTF-8 text encoded from codepoints array
 pub fn unloadUTF8(text: [:0]u8) void {
     cdef.UnloadUTF8(@as([*c]u8, @ptrCast(text)));
 }
 
+/// Unload codepoints data from memory
 pub fn unloadCodepoints(codepoints: []i32) void {
     cdef.UnloadCodepoints(@as([*c]c_int, @ptrCast(codepoints)));
 }
 
+/// Get total number of codepoints in a UTF-8 encoded string
 pub fn getCodepointCount(text: [:0]const u8) i32 {
     return @as(i32, cdef.GetCodepointCount(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepoint(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepoint(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
+/// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepointNext(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepointNext(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
+/// Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
 pub fn getCodepointPrevious(text: [:0]const u8, codepointSize: *i32) i32 {
     return @as(i32, cdef.GetCodepointPrevious(@as([*c]const u8, @ptrCast(text)), @as([*c]c_int, @ptrCast(codepointSize))));
 }
 
+/// Encode one codepoint into UTF-8 byte array (array length returned as parameter)
 pub fn codepointToUTF8(codepoint: i32, utf8Size: *i32) [:0]const u8 {
     return std.mem.span(cdef.CodepointToUTF8(@as(c_int, codepoint), @as([*c]c_int, @ptrCast(utf8Size))));
 }
 
+/// Copy one string to another, returns bytes copied
 pub fn textCopy(dst: *u8, src: [:0]const u8) i32 {
     return @as(i32, cdef.TextCopy(@as([*c]u8, @ptrCast(dst)), @as([*c]const u8, @ptrCast(src))));
 }
 
+/// Check if two text string are equal
 pub fn textIsEqual(text1: [:0]const u8, text2: [:0]const u8) bool {
     return cdef.TextIsEqual(@as([*c]const u8, @ptrCast(text1)), @as([*c]const u8, @ptrCast(text2)));
 }
 
+/// Get text length, checks for '\0' ending
 pub fn textLength(text: [:0]const u8) u32 {
     return @as(u32, cdef.TextLength(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get a piece of a text string
 pub fn textSubtext(text: [:0]const u8, position: i32, length: i32) [:0]const u8 {
     return std.mem.span(cdef.TextSubtext(@as([*c]const u8, @ptrCast(text)), @as(c_int, position), @as(c_int, length)));
 }
 
+/// Replace text string (WARNING: memory must be freed!)
 pub fn textReplace(text: [:0]const u8, replace: [:0]const u8, by: [:0]const u8) [:0]u8 {
     return std.mem.span(cdef.TextReplace(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(replace)), @as([*c]const u8, @ptrCast(by))));
 }
 
+/// Insert text in a position (WARNING: memory must be freed!)
 pub fn textInsert(text: [:0]const u8, insert: [:0]const u8, position: i32) [:0]u8 {
     return std.mem.span(cdef.TextInsert(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(insert)), @as(c_int, position)));
 }
 
+/// Append text at specific position and move cursor!
 pub fn textAppend(text: [:0]u8, append: [:0]const u8, position: *i32) void {
     cdef.TextAppend(@as([*c]u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(append)), @as([*c]c_int, @ptrCast(position)));
 }
 
+/// Find first text occurrence within a string
 pub fn textFindIndex(text: [:0]const u8, find: [:0]const u8) i32 {
     return @as(i32, cdef.TextFindIndex(@as([*c]const u8, @ptrCast(text)), @as([*c]const u8, @ptrCast(find))));
 }
 
+/// Get upper case version of provided string
 pub fn textToUpper(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToUpper(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get lower case version of provided string
 pub fn textToLower(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToLower(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get Pascal case notation version of provided string
 pub fn textToPascal(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToPascal(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get Snake case notation version of provided string
 pub fn textToSnake(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToSnake(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get Camel case notation version of provided string
 pub fn textToCamel(text: [:0]const u8) [:0]const u8 {
     return std.mem.span(cdef.TextToCamel(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get integer value from text (negative values not supported)
 pub fn textToInteger(text: [:0]const u8) i32 {
     return @as(i32, cdef.TextToInteger(@as([*c]const u8, @ptrCast(text))));
 }
 
+/// Get float value from text (negative values not supported)
 pub fn textToFloat(text: [:0]const u8) f32 {
     return cdef.TextToFloat(@as([*c]const u8, @ptrCast(text)));
 }
 
+/// Draw a line in 3D world space
 pub fn drawLine3D(startPos: Vector3, endPos: Vector3, color: Color) void {
     cdef.DrawLine3D(startPos, endPos, color);
 }
 
+/// Draw a point in 3D space, actually a small line
 pub fn drawPoint3D(position: Vector3, color: Color) void {
     cdef.DrawPoint3D(position, color);
 }
 
+/// Draw a circle in 3D world space
 pub fn drawCircle3D(center: Vector3, radius: f32, rotationAxis: Vector3, rotationAngle: f32, color: Color) void {
     cdef.DrawCircle3D(center, radius, rotationAxis, rotationAngle, color);
 }
 
+/// Draw a color-filled triangle (vertex in counter-clockwise order!)
 pub fn drawTriangle3D(v1: Vector3, v2: Vector3, v3: Vector3, color: Color) void {
     cdef.DrawTriangle3D(v1, v2, v3, color);
 }
 
+/// Draw cube
 pub fn drawCube(position: Vector3, width: f32, height: f32, length: f32, color: Color) void {
     cdef.DrawCube(position, width, height, length, color);
 }
 
+/// Draw cube (Vector version)
 pub fn drawCubeV(position: Vector3, size: Vector3, color: Color) void {
     cdef.DrawCubeV(position, size, color);
 }
 
+/// Draw cube wires
 pub fn drawCubeWires(position: Vector3, width: f32, height: f32, length: f32, color: Color) void {
     cdef.DrawCubeWires(position, width, height, length, color);
 }
 
+/// Draw cube wires (Vector version)
 pub fn drawCubeWiresV(position: Vector3, size: Vector3, color: Color) void {
     cdef.DrawCubeWiresV(position, size, color);
 }
 
+/// Draw sphere
 pub fn drawSphere(centerPos: Vector3, radius: f32, color: Color) void {
     cdef.DrawSphere(centerPos, radius, color);
 }
 
+/// Draw sphere with extended parameters
 pub fn drawSphereEx(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) void {
     cdef.DrawSphereEx(centerPos, radius, @as(c_int, rings), @as(c_int, slices), color);
 }
 
+/// Draw sphere wires
 pub fn drawSphereWires(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) void {
     cdef.DrawSphereWires(centerPos, radius, @as(c_int, rings), @as(c_int, slices), color);
 }
 
+/// Draw a cylinder/cone
 pub fn drawCylinder(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) void {
     cdef.DrawCylinder(position, radiusTop, radiusBottom, height, @as(c_int, slices), color);
 }
 
+/// Draw a cylinder with base at startPos and top at endPos
 pub fn drawCylinderEx(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) void {
     cdef.DrawCylinderEx(startPos, endPos, startRadius, endRadius, @as(c_int, sides), color);
 }
 
+/// Draw a cylinder/cone wires
 pub fn drawCylinderWires(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) void {
     cdef.DrawCylinderWires(position, radiusTop, radiusBottom, height, @as(c_int, slices), color);
 }
 
+/// Draw a cylinder wires with base at startPos and top at endPos
 pub fn drawCylinderWiresEx(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) void {
     cdef.DrawCylinderWiresEx(startPos, endPos, startRadius, endRadius, @as(c_int, sides), color);
 }
 
+/// Draw a capsule with the center of its sphere caps at startPos and endPos
 pub fn drawCapsule(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) void {
     cdef.DrawCapsule(startPos, endPos, radius, @as(c_int, slices), @as(c_int, rings), color);
 }
 
+/// Draw capsule wireframe with the center of its sphere caps at startPos and endPos
 pub fn drawCapsuleWires(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) void {
     cdef.DrawCapsuleWires(startPos, endPos, radius, @as(c_int, slices), @as(c_int, rings), color);
 }
 
+/// Draw a plane XZ
 pub fn drawPlane(centerPos: Vector3, size: Vector2, color: Color) void {
     cdef.DrawPlane(centerPos, size, color);
 }
 
+/// Draw a ray line
 pub fn drawRay(ray: Ray, color: Color) void {
     cdef.DrawRay(ray, color);
 }
 
+/// Draw a grid (centered at (0, 0, 0))
 pub fn drawGrid(slices: i32, spacing: f32) void {
     cdef.DrawGrid(@as(c_int, slices), spacing);
 }
 
+/// Load model from files (meshes and materials)
 pub fn loadModel(fileName: [:0]const u8) Model {
     return cdef.LoadModel(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load model from generated mesh (default material)
 pub fn loadModelFromMesh(mesh: Mesh) Model {
     return cdef.LoadModelFromMesh(mesh);
 }
 
+/// Check if a model is ready
 pub fn isModelReady(model: Model) bool {
     return cdef.IsModelReady(model);
 }
 
+/// Unload model (including meshes) from memory (RAM and/or VRAM)
 pub fn unloadModel(model: Model) void {
     cdef.UnloadModel(model);
 }
 
+/// Compute model bounding box limits (considers all meshes)
 pub fn getModelBoundingBox(model: Model) BoundingBox {
     return cdef.GetModelBoundingBox(model);
 }
 
+/// Draw a model (with texture if set)
 pub fn drawModel(model: Model, position: Vector3, scale: f32, tint: Color) void {
     cdef.DrawModel(model, position, scale, tint);
 }
 
+/// Draw a model with extended parameters
 pub fn drawModelEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
     cdef.DrawModelEx(model, position, rotationAxis, rotationAngle, scale, tint);
 }
 
+/// Draw a model wires (with texture if set)
 pub fn drawModelWires(model: Model, position: Vector3, scale: f32, tint: Color) void {
     cdef.DrawModelWires(model, position, scale, tint);
 }
 
+/// Draw a model wires (with texture if set) with extended parameters
 pub fn drawModelWiresEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) void {
     cdef.DrawModelWiresEx(model, position, rotationAxis, rotationAngle, scale, tint);
 }
 
+/// Draw bounding box (wires)
 pub fn drawBoundingBox(box: BoundingBox, color: Color) void {
     cdef.DrawBoundingBox(box, color);
 }
 
+/// Draw a billboard texture
 pub fn drawBillboard(camera: Camera, texture: Texture2D, position: Vector3, size: f32, tint: Color) void {
     cdef.DrawBillboard(camera, texture, position, size, tint);
 }
 
+/// Draw a billboard texture defined by source
 pub fn drawBillboardRec(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, size: Vector2, tint: Color) void {
     cdef.DrawBillboardRec(camera, texture, source, position, size, tint);
 }
 
+/// Draw a billboard texture defined by source and rotation
 pub fn drawBillboardPro(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: f32, tint: Color) void {
     cdef.DrawBillboardPro(camera, texture, source, position, up, size, origin, rotation, tint);
 }
 
+/// Upload mesh vertex data in GPU and provide VAO/VBO ids
 pub fn uploadMesh(mesh: *Mesh, dynamic: bool) void {
     cdef.UploadMesh(@as([*c]Mesh, @ptrCast(mesh)), dynamic);
 }
 
+/// Update mesh vertex data in GPU for a specific buffer index
 pub fn updateMeshBuffer(mesh: Mesh, index: i32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.UpdateMeshBuffer(mesh, @as(c_int, index), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
+/// Unload mesh data from CPU and GPU
 pub fn unloadMesh(mesh: Mesh) void {
     cdef.UnloadMesh(mesh);
 }
 
+/// Draw a 3d mesh with material and transform
 pub fn drawMesh(mesh: Mesh, material: Material, transform: Matrix) void {
     cdef.DrawMesh(mesh, material, transform);
 }
 
+/// Compute mesh bounding box limits
 pub fn getMeshBoundingBox(mesh: Mesh) BoundingBox {
     return cdef.GetMeshBoundingBox(mesh);
 }
 
+/// Compute mesh tangents
 pub fn genMeshTangents(mesh: *Mesh) void {
     cdef.GenMeshTangents(@as([*c]Mesh, @ptrCast(mesh)));
 }
 
+/// Export mesh data to file, returns true on success
 pub fn exportMesh(mesh: Mesh, fileName: [:0]const u8) bool {
     return cdef.ExportMesh(mesh, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Export mesh as code file (.h) defining multiple arrays of vertex attributes
 pub fn exportMeshAsCode(mesh: Mesh, fileName: [:0]const u8) bool {
     return cdef.ExportMeshAsCode(mesh, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Generate polygonal mesh
 pub fn genMeshPoly(sides: i32, radius: f32) Mesh {
     return cdef.GenMeshPoly(@as(c_int, sides), radius);
 }
 
+/// Generate plane mesh (with subdivisions)
 pub fn genMeshPlane(width: f32, length: f32, resX: i32, resZ: i32) Mesh {
     return cdef.GenMeshPlane(width, length, @as(c_int, resX), @as(c_int, resZ));
 }
 
+/// Generate cuboid mesh
 pub fn genMeshCube(width: f32, height: f32, length: f32) Mesh {
     return cdef.GenMeshCube(width, height, length);
 }
 
+/// Generate sphere mesh (standard sphere)
 pub fn genMeshSphere(radius: f32, rings: i32, slices: i32) Mesh {
     return cdef.GenMeshSphere(radius, @as(c_int, rings), @as(c_int, slices));
 }
 
+/// Generate half-sphere mesh (no bottom cap)
 pub fn genMeshHemiSphere(radius: f32, rings: i32, slices: i32) Mesh {
     return cdef.GenMeshHemiSphere(radius, @as(c_int, rings), @as(c_int, slices));
 }
 
+/// Generate cylinder mesh
 pub fn genMeshCylinder(radius: f32, height: f32, slices: i32) Mesh {
     return cdef.GenMeshCylinder(radius, height, @as(c_int, slices));
 }
 
+/// Generate cone/pyramid mesh
 pub fn genMeshCone(radius: f32, height: f32, slices: i32) Mesh {
     return cdef.GenMeshCone(radius, height, @as(c_int, slices));
 }
 
+/// Generate torus mesh
 pub fn genMeshTorus(radius: f32, size: f32, radSeg: i32, sides: i32) Mesh {
     return cdef.GenMeshTorus(radius, size, @as(c_int, radSeg), @as(c_int, sides));
 }
 
+/// Generate trefoil knot mesh
 pub fn genMeshKnot(radius: f32, size: f32, radSeg: i32, sides: i32) Mesh {
     return cdef.GenMeshKnot(radius, size, @as(c_int, radSeg), @as(c_int, sides));
 }
 
+/// Generate heightmap mesh from image data
 pub fn genMeshHeightmap(heightmap: Image, size: Vector3) Mesh {
     return cdef.GenMeshHeightmap(heightmap, size);
 }
 
+/// Generate cubes-based map mesh from image data
 pub fn genMeshCubicmap(cubicmap: Image, cubeSize: Vector3) Mesh {
     return cdef.GenMeshCubicmap(cubicmap, cubeSize);
 }
 
+/// Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
 pub fn loadMaterialDefault() Material {
     return cdef.LoadMaterialDefault();
 }
 
+/// Check if a material is ready
 pub fn isMaterialReady(material: Material) bool {
     return cdef.IsMaterialReady(material);
 }
 
+/// Unload material from GPU memory (VRAM)
 pub fn unloadMaterial(material: Material) void {
     cdef.UnloadMaterial(material);
 }
 
+/// Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
 pub fn setMaterialTexture(material: *Material, mapType: MaterialMapIndex, texture: Texture2D) void {
     cdef.SetMaterialTexture(@as([*c]Material, @ptrCast(material)), mapType, texture);
 }
 
+/// Set material for a mesh
 pub fn setModelMeshMaterial(model: *Model, meshId: i32, materialId: i32) void {
     cdef.SetModelMeshMaterial(@as([*c]Model, @ptrCast(model)), @as(c_int, meshId), @as(c_int, materialId));
 }
 
+/// Update model animation pose
 pub fn updateModelAnimation(model: Model, anim: ModelAnimation, frame: i32) void {
     cdef.UpdateModelAnimation(model, anim, @as(c_int, frame));
 }
 
+/// Unload animation data
 pub fn unloadModelAnimation(anim: ModelAnimation) void {
     cdef.UnloadModelAnimation(anim);
 }
 
+/// Check model animation skeleton match
 pub fn isModelAnimationValid(model: Model, anim: ModelAnimation) bool {
     return cdef.IsModelAnimationValid(model, anim);
 }
 
+/// Check collision between two spheres
 pub fn checkCollisionSpheres(center1: Vector3, radius1: f32, center2: Vector3, radius2: f32) bool {
     return cdef.CheckCollisionSpheres(center1, radius1, center2, radius2);
 }
 
+/// Check collision between two bounding boxes
 pub fn checkCollisionBoxes(box1: BoundingBox, box2: BoundingBox) bool {
     return cdef.CheckCollisionBoxes(box1, box2);
 }
 
+/// Check collision between box and sphere
 pub fn checkCollisionBoxSphere(box: BoundingBox, center: Vector3, radius: f32) bool {
     return cdef.CheckCollisionBoxSphere(box, center, radius);
 }
 
+/// Get collision info between ray and sphere
 pub fn getRayCollisionSphere(ray: Ray, center: Vector3, radius: f32) RayCollision {
     return cdef.GetRayCollisionSphere(ray, center, radius);
 }
 
+/// Get collision info between ray and box
 pub fn getRayCollisionBox(ray: Ray, box: BoundingBox) RayCollision {
     return cdef.GetRayCollisionBox(ray, box);
 }
 
+/// Get collision info between ray and mesh
 pub fn getRayCollisionMesh(ray: Ray, mesh: Mesh, transform: Matrix) RayCollision {
     return cdef.GetRayCollisionMesh(ray, mesh, transform);
 }
 
+/// Get collision info between ray and triangle
 pub fn getRayCollisionTriangle(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3) RayCollision {
     return cdef.GetRayCollisionTriangle(ray, p1, p2, p3);
 }
 
+/// Get collision info between ray and quad
 pub fn getRayCollisionQuad(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3, p4: Vector3) RayCollision {
     return cdef.GetRayCollisionQuad(ray, p1, p2, p3, p4);
 }
 
+/// Initialize audio device and context
 pub fn initAudioDevice() void {
     cdef.InitAudioDevice();
 }
 
+/// Close the audio device and context
 pub fn closeAudioDevice() void {
     cdef.CloseAudioDevice();
 }
 
+/// Check if audio device has been initialized successfully
 pub fn isAudioDeviceReady() bool {
     return cdef.IsAudioDeviceReady();
 }
 
+/// Set master volume (listener)
 pub fn setMasterVolume(volume: f32) void {
     cdef.SetMasterVolume(volume);
 }
 
+/// Get master volume (listener)
 pub fn getMasterVolume() f32 {
     return cdef.GetMasterVolume();
 }
 
+/// Load wave data from file
 pub fn loadWave(fileName: [:0]const u8) Wave {
     return cdef.LoadWave(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Checks if wave data is ready
 pub fn isWaveReady(wave: Wave) bool {
     return cdef.IsWaveReady(wave);
 }
 
+/// Load sound from file
 pub fn loadSound(fileName: [:0]const u8) Sound {
     return cdef.LoadSound(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Load sound from wave data
 pub fn loadSoundFromWave(wave: Wave) Sound {
     return cdef.LoadSoundFromWave(wave);
 }
 
+/// Create a new sound that shares the same sample data as the source sound, does not own the sound data
 pub fn loadSoundAlias(source: Sound) Sound {
     return cdef.LoadSoundAlias(source);
 }
 
+/// Checks if a sound is ready
 pub fn isSoundReady(sound: Sound) bool {
     return cdef.IsSoundReady(sound);
 }
 
+/// Update sound buffer with new data
 pub fn updateSound(sound: Sound, data: *const anyopaque, sampleCount: i32) void {
     cdef.UpdateSound(sound, data, @as(c_int, sampleCount));
 }
 
+/// Unload wave data
 pub fn unloadWave(wave: Wave) void {
     cdef.UnloadWave(wave);
 }
 
+/// Unload sound
 pub fn unloadSound(sound: Sound) void {
     cdef.UnloadSound(sound);
 }
 
+/// Unload a sound alias (does not deallocate sample data)
 pub fn unloadSoundAlias(alias: Sound) void {
     cdef.UnloadSoundAlias(alias);
 }
 
+/// Export wave data to file, returns true on success
 pub fn exportWave(wave: Wave, fileName: [:0]const u8) bool {
     return cdef.ExportWave(wave, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Export wave sample data to code (.h), returns true on success
 pub fn exportWaveAsCode(wave: Wave, fileName: [:0]const u8) bool {
     return cdef.ExportWaveAsCode(wave, @as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Play a sound
 pub fn playSound(sound: Sound) void {
     cdef.PlaySound(sound);
 }
 
+/// Stop playing a sound
 pub fn stopSound(sound: Sound) void {
     cdef.StopSound(sound);
 }
 
+/// Pause a sound
 pub fn pauseSound(sound: Sound) void {
     cdef.PauseSound(sound);
 }
 
+/// Resume a paused sound
 pub fn resumeSound(sound: Sound) void {
     cdef.ResumeSound(sound);
 }
 
+/// Check if a sound is currently playing
 pub fn isSoundPlaying(sound: Sound) bool {
     return cdef.IsSoundPlaying(sound);
 }
 
+/// Set volume for a sound (1.0 is max level)
 pub fn setSoundVolume(sound: Sound, volume: f32) void {
     cdef.SetSoundVolume(sound, volume);
 }
 
+/// Set pitch for a sound (1.0 is base level)
 pub fn setSoundPitch(sound: Sound, pitch: f32) void {
     cdef.SetSoundPitch(sound, pitch);
 }
 
+/// Set pan for a sound (0.5 is center)
 pub fn setSoundPan(sound: Sound, pan: f32) void {
     cdef.SetSoundPan(sound, pan);
 }
 
+/// Copy a wave to a new wave
 pub fn waveCopy(wave: Wave) Wave {
     return cdef.WaveCopy(wave);
 }
 
+/// Crop a wave to defined frames range
 pub fn waveCrop(wave: *Wave, initFrame: i32, finalFrame: i32) void {
     cdef.WaveCrop(@as([*c]Wave, @ptrCast(wave)), @as(c_int, initFrame), @as(c_int, finalFrame));
 }
 
+/// Convert wave data to desired format
 pub fn waveFormat(wave: *Wave, sampleRate: i32, sampleSize: i32, channels: i32) void {
     cdef.WaveFormat(@as([*c]Wave, @ptrCast(wave)), @as(c_int, sampleRate), @as(c_int, sampleSize), @as(c_int, channels));
 }
 
+/// Unload samples data loaded with LoadWaveSamples()
 pub fn unloadWaveSamples(samples: []f32) void {
     cdef.UnloadWaveSamples(@as([*c]f32, @ptrCast(samples)));
 }
 
+/// Load music stream from file
 pub fn loadMusicStream(fileName: [:0]const u8) Music {
     return cdef.LoadMusicStream(@as([*c]const u8, @ptrCast(fileName)));
 }
 
+/// Checks if a music stream is ready
 pub fn isMusicReady(music: Music) bool {
     return cdef.IsMusicReady(music);
 }
 
+/// Unload music stream
 pub fn unloadMusicStream(music: Music) void {
     cdef.UnloadMusicStream(music);
 }
 
+/// Start music playing
 pub fn playMusicStream(music: Music) void {
     cdef.PlayMusicStream(music);
 }
 
+/// Check if music is playing
 pub fn isMusicStreamPlaying(music: Music) bool {
     return cdef.IsMusicStreamPlaying(music);
 }
 
+/// Updates buffers for music streaming
 pub fn updateMusicStream(music: Music) void {
     cdef.UpdateMusicStream(music);
 }
 
+/// Stop music playing
 pub fn stopMusicStream(music: Music) void {
     cdef.StopMusicStream(music);
 }
 
+/// Pause music playing
 pub fn pauseMusicStream(music: Music) void {
     cdef.PauseMusicStream(music);
 }
 
+/// Resume playing paused music
 pub fn resumeMusicStream(music: Music) void {
     cdef.ResumeMusicStream(music);
 }
 
+/// Seek music to a position (in seconds)
 pub fn seekMusicStream(music: Music, position: f32) void {
     cdef.SeekMusicStream(music, position);
 }
 
+/// Set volume for music (1.0 is max level)
 pub fn setMusicVolume(music: Music, volume: f32) void {
     cdef.SetMusicVolume(music, volume);
 }
 
+/// Set pitch for a music (1.0 is base level)
 pub fn setMusicPitch(music: Music, pitch: f32) void {
     cdef.SetMusicPitch(music, pitch);
 }
 
+/// Set pan for a music (0.5 is center)
 pub fn setMusicPan(music: Music, pan: f32) void {
     cdef.SetMusicPan(music, pan);
 }
 
+/// Get music time length (in seconds)
 pub fn getMusicTimeLength(music: Music) f32 {
     return cdef.GetMusicTimeLength(music);
 }
 
+/// Get current music time played (in seconds)
 pub fn getMusicTimePlayed(music: Music) f32 {
     return cdef.GetMusicTimePlayed(music);
 }
 
+/// Load audio stream (to stream raw audio pcm data)
 pub fn loadAudioStream(sampleRate: u32, sampleSize: u32, channels: u32) AudioStream {
     return cdef.LoadAudioStream(@as(c_uint, sampleRate), @as(c_uint, sampleSize), @as(c_uint, channels));
 }
 
+/// Checks if an audio stream is ready
 pub fn isAudioStreamReady(stream: AudioStream) bool {
     return cdef.IsAudioStreamReady(stream);
 }
 
+/// Unload audio stream and free memory
 pub fn unloadAudioStream(stream: AudioStream) void {
     cdef.UnloadAudioStream(stream);
 }
 
+/// Update audio stream buffers with data
 pub fn updateAudioStream(stream: AudioStream, data: *const anyopaque, frameCount: i32) void {
     cdef.UpdateAudioStream(stream, data, @as(c_int, frameCount));
 }
 
+/// Check if any audio stream buffers requires refill
 pub fn isAudioStreamProcessed(stream: AudioStream) bool {
     return cdef.IsAudioStreamProcessed(stream);
 }
 
+/// Play audio stream
 pub fn playAudioStream(stream: AudioStream) void {
     cdef.PlayAudioStream(stream);
 }
 
+/// Pause audio stream
 pub fn pauseAudioStream(stream: AudioStream) void {
     cdef.PauseAudioStream(stream);
 }
 
+/// Resume audio stream
 pub fn resumeAudioStream(stream: AudioStream) void {
     cdef.ResumeAudioStream(stream);
 }
 
+/// Check if audio stream is playing
 pub fn isAudioStreamPlaying(stream: AudioStream) bool {
     return cdef.IsAudioStreamPlaying(stream);
 }
 
+/// Stop audio stream
 pub fn stopAudioStream(stream: AudioStream) void {
     cdef.StopAudioStream(stream);
 }
 
+/// Set volume for audio stream (1.0 is max level)
 pub fn setAudioStreamVolume(stream: AudioStream, volume: f32) void {
     cdef.SetAudioStreamVolume(stream, volume);
 }
 
+/// Set pitch for audio stream (1.0 is base level)
 pub fn setAudioStreamPitch(stream: AudioStream, pitch: f32) void {
     cdef.SetAudioStreamPitch(stream, pitch);
 }
 
+/// Set pan for audio stream (0.5 is centered)
 pub fn setAudioStreamPan(stream: AudioStream, pan: f32) void {
     cdef.SetAudioStreamPan(stream, pan);
 }
 
+/// Default size for new audio streams
 pub fn setAudioStreamBufferSizeDefault(size: i32) void {
     cdef.SetAudioStreamBufferSizeDefault(@as(c_int, size));
 }
 
+/// Audio thread callback to request new data
 pub fn setAudioStreamCallback(stream: AudioStream, callback: AudioCallback) void {
     cdef.SetAudioStreamCallback(stream, callback);
 }
 
+/// Attach audio stream processor to stream, receives the samples as 'float'
 pub fn attachAudioStreamProcessor(stream: AudioStream, processor: AudioCallback) void {
     cdef.AttachAudioStreamProcessor(stream, processor);
 }
 
+/// Detach audio stream processor from stream
 pub fn detachAudioStreamProcessor(stream: AudioStream, processor: AudioCallback) void {
     cdef.DetachAudioStreamProcessor(stream, processor);
 }
 
+/// Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 pub fn attachAudioMixedProcessor(processor: AudioCallback) void {
     cdef.AttachAudioMixedProcessor(processor);
 }
 
+/// Detach audio stream processor from the entire audio pipeline
 pub fn detachAudioMixedProcessor(processor: AudioCallback) void {
     cdef.DetachAudioMixedProcessor(processor);
 }

--- a/lib/rlgl.zig
+++ b/lib/rlgl.zig
@@ -188,42 +188,34 @@ pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR = @as(i32, 3);
 pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT = @as(i32, 4);
 pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2 = @as(i32, 5);
 
-/// Choose the current matrix to be transformed
 pub fn rlMatrixMode(mode: i32) void {
     cdef.rlMatrixMode(@as(c_int, mode));
 }
 
-/// Push the current matrix to stack
 pub fn rlPushMatrix() void {
     cdef.rlPushMatrix();
 }
 
-/// Pop latest inserted matrix from stack
 pub fn rlPopMatrix() void {
     cdef.rlPopMatrix();
 }
 
-/// Reset current matrix to identity matrix
 pub fn rlLoadIdentity() void {
     cdef.rlLoadIdentity();
 }
 
-/// Multiply the current matrix by a translation matrix
 pub fn rlTranslatef(x: f32, y: f32, z: f32) void {
     cdef.rlTranslatef(x, y, z);
 }
 
-/// Multiply the current matrix by a rotation matrix
 pub fn rlRotatef(angle: f32, x: f32, y: f32, z: f32) void {
     cdef.rlRotatef(angle, x, y, z);
 }
 
-/// Multiply the current matrix by a scaling matrix
 pub fn rlScalef(x: f32, y: f32, z: f32) void {
     cdef.rlScalef(x, y, z);
 }
 
-/// Multiply the current matrix by another matrix
 pub fn rlMultMatrixf(matf: []const f32) void {
     cdef.rlMultMatrixf(@as([*c]const f32, @ptrCast(matf)));
 }
@@ -236,722 +228,578 @@ pub fn rlOrtho(left: f64, right: f64, bottom: f64, top: f64, znear: f64, zfar: f
     cdef.rlOrtho(left, right, bottom, top, znear, zfar);
 }
 
-/// Set the viewport area
 pub fn rlViewport(x: i32, y: i32, width: i32, height: i32) void {
     cdef.rlViewport(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
-/// Set clip planes distances
 pub fn rlSetClipPlanes(near: f64, far: f64) void {
     cdef.rlSetClipPlanes(near, far);
 }
 
-/// Get cull plane distance near
 pub fn rlGetCullDistanceNear() f64 {
     return cdef.rlGetCullDistanceNear();
 }
 
-/// Get cull plane distance far
 pub fn rlGetCullDistanceFar() f64 {
     return cdef.rlGetCullDistanceFar();
 }
 
-/// Initialize drawing mode (how to organize vertex)
 pub fn rlBegin(mode: i32) void {
     cdef.rlBegin(@as(c_int, mode));
 }
 
-/// Finish vertex providing
 pub fn rlEnd() void {
     cdef.rlEnd();
 }
 
-/// Define one vertex (position) - 2 int
 pub fn rlVertex2i(x: i32, y: i32) void {
     cdef.rlVertex2i(@as(c_int, x), @as(c_int, y));
 }
 
-/// Define one vertex (position) - 2 float
 pub fn rlVertex2f(x: f32, y: f32) void {
     cdef.rlVertex2f(x, y);
 }
 
-/// Define one vertex (position) - 3 float
 pub fn rlVertex3f(x: f32, y: f32, z: f32) void {
     cdef.rlVertex3f(x, y, z);
 }
 
-/// Define one vertex (texture coordinate) - 2 float
 pub fn rlTexCoord2f(x: f32, y: f32) void {
     cdef.rlTexCoord2f(x, y);
 }
 
-/// Define one vertex (normal) - 3 float
 pub fn rlNormal3f(x: f32, y: f32, z: f32) void {
     cdef.rlNormal3f(x, y, z);
 }
 
-/// Define one vertex (color) - 4 byte
 pub fn rlColor4ub(r: u8, g: u8, b: u8, a: u8) void {
     cdef.rlColor4ub(r, g, b, a);
 }
 
-/// Define one vertex (color) - 3 float
 pub fn rlColor3f(x: f32, y: f32, z: f32) void {
     cdef.rlColor3f(x, y, z);
 }
 
-/// Define one vertex (color) - 4 float
 pub fn rlColor4f(x: f32, y: f32, z: f32, w: f32) void {
     cdef.rlColor4f(x, y, z, w);
 }
 
-/// Enable vertex array (VAO, if supported)
 pub fn rlEnableVertexArray(vaoId: u32) bool {
     return cdef.rlEnableVertexArray(@as(c_uint, vaoId));
 }
 
-/// Disable vertex array (VAO, if supported)
 pub fn rlDisableVertexArray() void {
     cdef.rlDisableVertexArray();
 }
 
-/// Enable vertex buffer (VBO)
 pub fn rlEnableVertexBuffer(id: u32) void {
     cdef.rlEnableVertexBuffer(@as(c_uint, id));
 }
 
-/// Disable vertex buffer (VBO)
 pub fn rlDisableVertexBuffer() void {
     cdef.rlDisableVertexBuffer();
 }
 
-/// Enable vertex buffer element (VBO element)
 pub fn rlEnableVertexBufferElement(id: u32) void {
     cdef.rlEnableVertexBufferElement(@as(c_uint, id));
 }
 
-/// Disable vertex buffer element (VBO element)
 pub fn rlDisableVertexBufferElement() void {
     cdef.rlDisableVertexBufferElement();
 }
 
-/// Enable vertex attribute index
 pub fn rlEnableVertexAttribute(index: u32) void {
     cdef.rlEnableVertexAttribute(@as(c_uint, index));
 }
 
-/// Disable vertex attribute index
 pub fn rlDisableVertexAttribute(index: u32) void {
     cdef.rlDisableVertexAttribute(@as(c_uint, index));
 }
 
-/// Enable attribute state pointer
 pub fn rlEnableStatePointer(vertexAttribType: i32, buffer: *anyopaque) void {
     cdef.rlEnableStatePointer(@as(c_int, vertexAttribType), buffer);
 }
 
-/// Disable attribute state pointer
 pub fn rlDisableStatePointer(vertexAttribType: i32) void {
     cdef.rlDisableStatePointer(@as(c_int, vertexAttribType));
 }
 
-/// Select and active a texture slot
 pub fn rlActiveTextureSlot(slot: i32) void {
     cdef.rlActiveTextureSlot(@as(c_int, slot));
 }
 
-/// Enable texture
 pub fn rlEnableTexture(id: u32) void {
     cdef.rlEnableTexture(@as(c_uint, id));
 }
 
-/// Disable texture
 pub fn rlDisableTexture() void {
     cdef.rlDisableTexture();
 }
 
-/// Enable texture cubemap
 pub fn rlEnableTextureCubemap(id: u32) void {
     cdef.rlEnableTextureCubemap(@as(c_uint, id));
 }
 
-/// Disable texture cubemap
 pub fn rlDisableTextureCubemap() void {
     cdef.rlDisableTextureCubemap();
 }
 
-/// Set texture parameters (filter, wrap)
 pub fn rlTextureParameters(id: u32, param: i32, value: i32) void {
     cdef.rlTextureParameters(@as(c_uint, id), @as(c_int, param), @as(c_int, value));
 }
 
-/// Set cubemap parameters (filter, wrap)
 pub fn rlCubemapParameters(id: u32, param: i32, value: i32) void {
     cdef.rlCubemapParameters(@as(c_uint, id), @as(c_int, param), @as(c_int, value));
 }
 
-/// Enable shader program
 pub fn rlEnableShader(id: u32) void {
     cdef.rlEnableShader(@as(c_uint, id));
 }
 
-/// Disable shader program
 pub fn rlDisableShader() void {
     cdef.rlDisableShader();
 }
 
-/// Enable render texture (fbo)
 pub fn rlEnableFramebuffer(id: u32) void {
     cdef.rlEnableFramebuffer(@as(c_uint, id));
 }
 
-/// Disable render texture (fbo), return to default framebuffer
 pub fn rlDisableFramebuffer() void {
     cdef.rlDisableFramebuffer();
 }
 
-/// Get the currently active render texture (fbo), 0 for default framebuffer
 pub fn rlGetActiveFramebuffer() u32 {
     return @as(u32, cdef.rlGetActiveFramebuffer());
 }
 
-/// Activate multiple draw color buffers
 pub fn rlActiveDrawBuffers(count: i32) void {
     cdef.rlActiveDrawBuffers(@as(c_int, count));
 }
 
-/// Blit active framebuffer to main framebuffer
 pub fn rlBlitFramebuffer(srcX: i32, srcY: i32, srcWidth: i32, srcHeight: i32, dstX: i32, dstY: i32, dstWidth: i32, dstHeight: i32, bufferMask: i32) void {
     cdef.rlBlitFramebuffer(@as(c_int, srcX), @as(c_int, srcY), @as(c_int, srcWidth), @as(c_int, srcHeight), @as(c_int, dstX), @as(c_int, dstY), @as(c_int, dstWidth), @as(c_int, dstHeight), @as(c_int, bufferMask));
 }
 
-/// Bind framebuffer (FBO)
 pub fn rlBindFramebuffer(target: u32, framebuffer: u32) void {
     cdef.rlBindFramebuffer(@as(c_uint, target), @as(c_uint, framebuffer));
 }
 
-/// Enable color blending
 pub fn rlEnableColorBlend() void {
     cdef.rlEnableColorBlend();
 }
 
-/// Disable color blending
 pub fn rlDisableColorBlend() void {
     cdef.rlDisableColorBlend();
 }
 
-/// Enable depth test
 pub fn rlEnableDepthTest() void {
     cdef.rlEnableDepthTest();
 }
 
-/// Disable depth test
 pub fn rlDisableDepthTest() void {
     cdef.rlDisableDepthTest();
 }
 
-/// Enable depth write
 pub fn rlEnableDepthMask() void {
     cdef.rlEnableDepthMask();
 }
 
-/// Disable depth write
 pub fn rlDisableDepthMask() void {
     cdef.rlDisableDepthMask();
 }
 
-/// Enable backface culling
 pub fn rlEnableBackfaceCulling() void {
     cdef.rlEnableBackfaceCulling();
 }
 
-/// Disable backface culling
 pub fn rlDisableBackfaceCulling() void {
     cdef.rlDisableBackfaceCulling();
 }
 
-/// Color mask control
 pub fn rlColorMask(r: bool, g: bool, b: bool, a: bool) void {
     cdef.rlColorMask(r, g, b, a);
 }
 
-/// Set face culling mode
 pub fn rlSetCullFace(mode: i32) void {
     cdef.rlSetCullFace(@as(c_int, mode));
 }
 
-/// Enable scissor test
 pub fn rlEnableScissorTest() void {
     cdef.rlEnableScissorTest();
 }
 
-/// Disable scissor test
 pub fn rlDisableScissorTest() void {
     cdef.rlDisableScissorTest();
 }
 
-/// Scissor test
 pub fn rlScissor(x: i32, y: i32, width: i32, height: i32) void {
     cdef.rlScissor(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
-/// Enable wire mode
 pub fn rlEnableWireMode() void {
     cdef.rlEnableWireMode();
 }
 
-/// Enable point mode
 pub fn rlEnablePointMode() void {
     cdef.rlEnablePointMode();
 }
 
-/// Disable wire mode ( and point ) maybe rename
 pub fn rlDisableWireMode() void {
     cdef.rlDisableWireMode();
 }
 
-/// Set the line drawing width
 pub fn rlSetLineWidth(width: f32) void {
     cdef.rlSetLineWidth(width);
 }
 
-/// Get the line drawing width
 pub fn rlGetLineWidth() f32 {
     return cdef.rlGetLineWidth();
 }
 
-/// Enable line aliasing
 pub fn rlEnableSmoothLines() void {
     cdef.rlEnableSmoothLines();
 }
 
-/// Disable line aliasing
 pub fn rlDisableSmoothLines() void {
     cdef.rlDisableSmoothLines();
 }
 
-/// Enable stereo rendering
 pub fn rlEnableStereoRender() void {
     cdef.rlEnableStereoRender();
 }
 
-/// Disable stereo rendering
 pub fn rlDisableStereoRender() void {
     cdef.rlDisableStereoRender();
 }
 
-/// Check if stereo render is enabled
 pub fn rlIsStereoRenderEnabled() bool {
     return cdef.rlIsStereoRenderEnabled();
 }
 
-/// Clear color buffer with color
 pub fn rlClearColor(r: u8, g: u8, b: u8, a: u8) void {
     cdef.rlClearColor(r, g, b, a);
 }
 
-/// Clear used screen buffers (color and depth)
 pub fn rlClearScreenBuffers() void {
     cdef.rlClearScreenBuffers();
 }
 
-/// Check and log OpenGL error codes
 pub fn rlCheckErrors() void {
     cdef.rlCheckErrors();
 }
 
-/// Set blending mode
 pub fn rlSetBlendMode(mode: i32) void {
     cdef.rlSetBlendMode(@as(c_int, mode));
 }
 
-/// Set blending mode factor and equation (using OpenGL factors)
 pub fn rlSetBlendFactors(glSrcFactor: i32, glDstFactor: i32, glEquation: i32) void {
     cdef.rlSetBlendFactors(@as(c_int, glSrcFactor), @as(c_int, glDstFactor), @as(c_int, glEquation));
 }
 
-/// Set blending mode factors and equations separately (using OpenGL factors)
 pub fn rlSetBlendFactorsSeparate(glSrcRGB: i32, glDstRGB: i32, glSrcAlpha: i32, glDstAlpha: i32, glEqRGB: i32, glEqAlpha: i32) void {
     cdef.rlSetBlendFactorsSeparate(@as(c_int, glSrcRGB), @as(c_int, glDstRGB), @as(c_int, glSrcAlpha), @as(c_int, glDstAlpha), @as(c_int, glEqRGB), @as(c_int, glEqAlpha));
 }
 
-/// Initialize rlgl (buffers, shaders, textures, states)
 pub fn rlglInit(width: i32, height: i32) void {
     cdef.rlglInit(@as(c_int, width), @as(c_int, height));
 }
 
-/// De-initialize rlgl (buffers, shaders, textures)
 pub fn rlglClose() void {
     cdef.rlglClose();
 }
 
-/// Load OpenGL extensions (loader function required)
 pub fn rlLoadExtensions(loader: *anyopaque) void {
     cdef.rlLoadExtensions(loader);
 }
 
-/// Get current OpenGL version
 pub fn rlGetVersion() i32 {
     return @as(i32, cdef.rlGetVersion());
 }
 
-/// Set current framebuffer width
 pub fn rlSetFramebufferWidth(width: i32) void {
     cdef.rlSetFramebufferWidth(@as(c_int, width));
 }
 
-/// Get default framebuffer width
 pub fn rlGetFramebufferWidth() i32 {
     return @as(i32, cdef.rlGetFramebufferWidth());
 }
 
-/// Set current framebuffer height
 pub fn rlSetFramebufferHeight(height: i32) void {
     cdef.rlSetFramebufferHeight(@as(c_int, height));
 }
 
-/// Get default framebuffer height
 pub fn rlGetFramebufferHeight() i32 {
     return @as(i32, cdef.rlGetFramebufferHeight());
 }
 
-/// Get default texture id
 pub fn rlGetTextureIdDefault() u32 {
     return @as(u32, cdef.rlGetTextureIdDefault());
 }
 
-/// Get default shader id
 pub fn rlGetShaderIdDefault() u32 {
     return @as(u32, cdef.rlGetShaderIdDefault());
 }
 
-/// Load a render batch system
 pub fn rlLoadRenderBatch(numBuffers: i32, bufferElements: i32) rlRenderBatch {
     return cdef.rlLoadRenderBatch(@as(c_int, numBuffers), @as(c_int, bufferElements));
 }
 
-/// Unload render batch system
 pub fn rlUnloadRenderBatch(batch: rlRenderBatch) void {
     cdef.rlUnloadRenderBatch(batch);
 }
 
-/// Draw render batch data (Update->Draw->Reset)
 pub fn rlDrawRenderBatch(batch: *rlRenderBatch) void {
     cdef.rlDrawRenderBatch(@as([*c]rlRenderBatch, @ptrCast(batch)));
 }
 
-/// Set the active render batch for rlgl (NULL for default internal)
 pub fn rlSetRenderBatchActive(batch: *rlRenderBatch) void {
     cdef.rlSetRenderBatchActive(@as([*c]rlRenderBatch, @ptrCast(batch)));
 }
 
-/// Update and draw internal render batch
 pub fn rlDrawRenderBatchActive() void {
     cdef.rlDrawRenderBatchActive();
 }
 
-/// Check internal buffer overflow for a given number of vertex
 pub fn rlCheckRenderBatchLimit(vCount: i32) bool {
     return cdef.rlCheckRenderBatchLimit(@as(c_int, vCount));
 }
 
-/// Set current texture for render batch and check buffers limits
 pub fn rlSetTexture(id: u32) void {
     cdef.rlSetTexture(@as(c_uint, id));
 }
 
-/// Load vertex array (vao) if supported
 pub fn rlLoadVertexArray() u32 {
     return @as(u32, cdef.rlLoadVertexArray());
 }
 
-/// Load a vertex buffer object
 pub fn rlLoadVertexBuffer(buffer: *const anyopaque, size: i32, dynamic: bool) u32 {
     return @as(u32, cdef.rlLoadVertexBuffer(buffer, @as(c_int, size), dynamic));
 }
 
-/// Load vertex buffer elements object
 pub fn rlLoadVertexBufferElement(buffer: *const anyopaque, size: i32, dynamic: bool) u32 {
     return @as(u32, cdef.rlLoadVertexBufferElement(buffer, @as(c_int, size), dynamic));
 }
 
-/// Update vertex buffer object data on GPU buffer
 pub fn rlUpdateVertexBuffer(bufferId: u32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.rlUpdateVertexBuffer(@as(c_uint, bufferId), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
-/// Update vertex buffer elements data on GPU buffer
 pub fn rlUpdateVertexBufferElements(id: u32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.rlUpdateVertexBufferElements(@as(c_uint, id), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
-/// Unload vertex array (vao)
 pub fn rlUnloadVertexArray(vaoId: u32) void {
     cdef.rlUnloadVertexArray(@as(c_uint, vaoId));
 }
 
-/// Unload vertex buffer object
 pub fn rlUnloadVertexBuffer(vboId: u32) void {
     cdef.rlUnloadVertexBuffer(@as(c_uint, vboId));
 }
 
-/// Set vertex attribute data configuration
 pub fn rlSetVertexAttribute(index: u32, compSize: i32, ty: i32, normalized: bool, stride: i32, offset: i32) void {
     cdef.rlSetVertexAttribute(@as(c_uint, index), @as(c_int, compSize), @as(c_int, ty), normalized, @as(c_int, stride), @as(c_int, offset));
 }
 
-/// Set vertex attribute data divisor
 pub fn rlSetVertexAttributeDivisor(index: u32, divisor: i32) void {
     cdef.rlSetVertexAttributeDivisor(@as(c_uint, index), @as(c_int, divisor));
 }
 
-/// Set vertex attribute default value, when attribute to provided
 pub fn rlSetVertexAttributeDefault(locIndex: i32, value: *const anyopaque, attribType: i32, count: i32) void {
     cdef.rlSetVertexAttributeDefault(@as(c_int, locIndex), value, @as(c_int, attribType), @as(c_int, count));
 }
 
-/// Draw vertex array (currently active vao)
 pub fn rlDrawVertexArray(offset: i32, count: i32) void {
     cdef.rlDrawVertexArray(@as(c_int, offset), @as(c_int, count));
 }
 
-/// Draw vertex array elements
 pub fn rlDrawVertexArrayElements(offset: i32, count: i32, buffer: ?*const anyopaque) void {
     cdef.rlDrawVertexArrayElements(@as(c_int, offset), @as(c_int, count), buffer);
 }
 
-/// Draw vertex array (currently active vao) with instancing
 pub fn rlDrawVertexArrayInstanced(offset: i32, count: i32, instances: i32) void {
     cdef.rlDrawVertexArrayInstanced(@as(c_int, offset), @as(c_int, count), @as(c_int, instances));
 }
 
-/// Draw vertex array elements with instancing
 pub fn rlDrawVertexArrayElementsInstanced(offset: i32, count: i32, buffer: ?*const anyopaque, instances: i32) void {
     cdef.rlDrawVertexArrayElementsInstanced(@as(c_int, offset), @as(c_int, count), buffer, @as(c_int, instances));
 }
 
-/// Load texture data
 pub fn rlLoadTexture(data: *const anyopaque, width: i32, height: i32, format: i32, mipmapCount: i32) u32 {
     return @as(u32, cdef.rlLoadTexture(data, @as(c_int, width), @as(c_int, height), @as(c_int, format), @as(c_int, mipmapCount)));
 }
 
-/// Load depth texture/renderbuffer (to be attached to fbo)
 pub fn rlLoadTextureDepth(width: i32, height: i32, useRenderBuffer: bool) u32 {
     return @as(u32, cdef.rlLoadTextureDepth(@as(c_int, width), @as(c_int, height), useRenderBuffer));
 }
 
-/// Load texture cubemap data
 pub fn rlLoadTextureCubemap(data: *const anyopaque, size: i32, format: i32) u32 {
     return @as(u32, cdef.rlLoadTextureCubemap(data, @as(c_int, size), @as(c_int, format)));
 }
 
-/// Update texture with new data on GPU
 pub fn rlUpdateTexture(id: u32, offsetX: i32, offsetY: i32, width: i32, height: i32, format: i32, data: *const anyopaque) void {
     cdef.rlUpdateTexture(@as(c_uint, id), @as(c_int, offsetX), @as(c_int, offsetY), @as(c_int, width), @as(c_int, height), @as(c_int, format), data);
 }
 
-/// Get OpenGL internal formats
 pub fn rlGetGlTextureFormats(format: i32, glInternalFormat: *u32, glFormat: *u32, glType: *u32) void {
     cdef.rlGetGlTextureFormats(@as(c_int, format), @as([*c]c_uint, @ptrCast(glInternalFormat)), @as([*c]c_uint, @ptrCast(glFormat)), @as([*c]c_uint, @ptrCast(glType)));
 }
 
-/// Get name string for pixel format
 pub fn rlGetPixelFormatName(format: u32) [:0]const u8 {
     return std.mem.span(cdef.rlGetPixelFormatName(@as(c_uint, format)));
 }
 
-/// Unload texture from GPU memory
 pub fn rlUnloadTexture(id: u32) void {
     cdef.rlUnloadTexture(@as(c_uint, id));
 }
 
-/// Generate mipmap data for selected texture
 pub fn rlGenTextureMipmaps(id: u32, width: i32, height: i32, format: i32, mipmaps: *i32) void {
     cdef.rlGenTextureMipmaps(@as(c_uint, id), @as(c_int, width), @as(c_int, height), @as(c_int, format), @as([*c]c_int, @ptrCast(mipmaps)));
 }
 
-/// Read texture pixel data
 pub fn rlReadTexturePixels(id: u32, width: i32, height: i32, format: i32) *anyopaque {
     return cdef.rlReadTexturePixels(@as(c_uint, id), @as(c_int, width), @as(c_int, height), @as(c_int, format));
 }
 
-/// Read screen pixel data (color buffer)
 pub fn rlReadScreenPixels(width: i32, height: i32) [:0]u8 {
     return std.mem.span(cdef.rlReadScreenPixels(@as(c_int, width), @as(c_int, height)));
 }
 
-/// Load an empty framebuffer
 pub fn rlLoadFramebuffer() u32 {
     return @as(u32, cdef.rlLoadFramebuffer());
 }
 
-/// Attach texture/renderbuffer to a framebuffer
 pub fn rlFramebufferAttach(fboId: u32, texId: u32, attachType: i32, texType: i32, mipLevel: i32) void {
     cdef.rlFramebufferAttach(@as(c_uint, fboId), @as(c_uint, texId), @as(c_int, attachType), @as(c_int, texType), @as(c_int, mipLevel));
 }
 
-/// Verify framebuffer is complete
 pub fn rlFramebufferComplete(id: u32) bool {
     return cdef.rlFramebufferComplete(@as(c_uint, id));
 }
 
-/// Delete framebuffer from GPU
 pub fn rlUnloadFramebuffer(id: u32) void {
     cdef.rlUnloadFramebuffer(@as(c_uint, id));
 }
 
-/// Load shader from code strings
 pub fn rlLoadShaderCode(vsCode: [:0]const u8, fsCode: [:0]const u8) u32 {
     return @as(u32, cdef.rlLoadShaderCode(@as([*c]const u8, @ptrCast(vsCode)), @as([*c]const u8, @ptrCast(fsCode))));
 }
 
-/// Compile custom shader and return shader id (type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER)
 pub fn rlCompileShader(shaderCode: [:0]const u8, ty: i32) u32 {
     return @as(u32, cdef.rlCompileShader(@as([*c]const u8, @ptrCast(shaderCode)), @as(c_int, ty)));
 }
 
-/// Load custom shader program
 pub fn rlLoadShaderProgram(vShaderId: u32, fShaderId: u32) u32 {
     return @as(u32, cdef.rlLoadShaderProgram(@as(c_uint, vShaderId), @as(c_uint, fShaderId)));
 }
 
-/// Unload shader program
 pub fn rlUnloadShaderProgram(id: u32) void {
     cdef.rlUnloadShaderProgram(@as(c_uint, id));
 }
 
-/// Get shader location uniform
 pub fn rlGetLocationUniform(shaderId: u32, uniformName: [:0]const u8) i32 {
     return @as(i32, cdef.rlGetLocationUniform(@as(c_uint, shaderId), @as([*c]const u8, @ptrCast(uniformName))));
 }
 
-/// Get shader location attribute
 pub fn rlGetLocationAttrib(shaderId: u32, attribName: [:0]const u8) i32 {
     return @as(i32, cdef.rlGetLocationAttrib(@as(c_uint, shaderId), @as([*c]const u8, @ptrCast(attribName))));
 }
 
-/// Set shader value uniform
 pub fn rlSetUniform(locIndex: i32, value: *const anyopaque, uniformType: i32, count: i32) void {
     cdef.rlSetUniform(@as(c_int, locIndex), value, @as(c_int, uniformType), @as(c_int, count));
 }
 
-/// Set shader value matrix
 pub fn rlSetUniformMatrix(locIndex: i32, mat: Matrix) void {
     cdef.rlSetUniformMatrix(@as(c_int, locIndex), mat);
 }
 
-/// Set shader value sampler
 pub fn rlSetUniformSampler(locIndex: i32, textureId: u32) void {
     cdef.rlSetUniformSampler(@as(c_int, locIndex), @as(c_uint, textureId));
 }
 
-/// Set shader currently active (id and locations)
 pub fn rlSetShader(id: u32, locs: []i32) void {
     cdef.rlSetShader(@as(c_uint, id), @as([*c]c_int, @ptrCast(locs)));
 }
 
-/// Load compute shader program
 pub fn rlLoadComputeShaderProgram(shaderId: u32) u32 {
     return @as(u32, cdef.rlLoadComputeShaderProgram(@as(c_uint, shaderId)));
 }
 
-/// Dispatch compute shader (equivalent to *draw* for graphics pipeline)
 pub fn rlComputeShaderDispatch(groupX: u32, groupY: u32, groupZ: u32) void {
     cdef.rlComputeShaderDispatch(@as(c_uint, groupX), @as(c_uint, groupY), @as(c_uint, groupZ));
 }
 
-/// Load shader storage buffer object (SSBO)
 pub fn rlLoadShaderBuffer(size: u32, data: *const anyopaque, usageHint: i32) u32 {
     return @as(u32, cdef.rlLoadShaderBuffer(@as(c_uint, size), data, @as(c_int, usageHint)));
 }
 
-/// Unload shader storage buffer object (SSBO)
 pub fn rlUnloadShaderBuffer(ssboId: u32) void {
     cdef.rlUnloadShaderBuffer(@as(c_uint, ssboId));
 }
 
-/// Update SSBO buffer data
 pub fn rlUpdateShaderBuffer(id: u32, data: *const anyopaque, dataSize: u32, offset: u32) void {
     cdef.rlUpdateShaderBuffer(@as(c_uint, id), data, @as(c_uint, dataSize), @as(c_uint, offset));
 }
 
-/// Bind SSBO buffer
 pub fn rlBindShaderBuffer(id: u32, index: u32) void {
     cdef.rlBindShaderBuffer(@as(c_uint, id), @as(c_uint, index));
 }
 
-/// Read SSBO buffer data (GPU->CPU)
 pub fn rlReadShaderBuffer(id: u32, dest: *anyopaque, count: u32, offset: u32) void {
     cdef.rlReadShaderBuffer(@as(c_uint, id), dest, @as(c_uint, count), @as(c_uint, offset));
 }
 
-/// Copy SSBO data between buffers
 pub fn rlCopyShaderBuffer(destId: u32, srcId: u32, destOffset: u32, srcOffset: u32, count: u32) void {
     cdef.rlCopyShaderBuffer(@as(c_uint, destId), @as(c_uint, srcId), @as(c_uint, destOffset), @as(c_uint, srcOffset), @as(c_uint, count));
 }
 
-/// Get SSBO buffer size
 pub fn rlGetShaderBufferSize(id: u32) u32 {
     return @as(u32, cdef.rlGetShaderBufferSize(@as(c_uint, id)));
 }
 
-/// Bind image texture
 pub fn rlBindImageTexture(id: u32, index: u32, format: i32, readonly: bool) void {
     cdef.rlBindImageTexture(@as(c_uint, id), @as(c_uint, index), @as(c_int, format), readonly);
 }
 
-/// Get internal modelview matrix
 pub fn rlGetMatrixModelview() Matrix {
     return cdef.rlGetMatrixModelview();
 }
 
-/// Get internal projection matrix
 pub fn rlGetMatrixProjection() Matrix {
     return cdef.rlGetMatrixProjection();
 }
 
-/// Get internal accumulated transform matrix
 pub fn rlGetMatrixTransform() Matrix {
     return cdef.rlGetMatrixTransform();
 }
 
-/// Get internal projection matrix for stereo render (selected eye)
 pub fn rlGetMatrixProjectionStereo(eye: i32) Matrix {
     return cdef.rlGetMatrixProjectionStereo(@as(c_int, eye));
 }
 
-/// Get internal view offset matrix for stereo render (selected eye)
 pub fn rlGetMatrixViewOffsetStereo(eye: i32) Matrix {
     return cdef.rlGetMatrixViewOffsetStereo(@as(c_int, eye));
 }
 
-/// Set a custom projection matrix (replaces internal projection matrix)
 pub fn rlSetMatrixProjection(proj: Matrix) void {
     cdef.rlSetMatrixProjection(proj);
 }
 
-/// Set a custom modelview matrix (replaces internal modelview matrix)
 pub fn rlSetMatrixModelview(view: Matrix) void {
     cdef.rlSetMatrixModelview(view);
 }
 
-/// Set eyes projection matrices for stereo rendering
 pub fn rlSetMatrixProjectionStereo(right: Matrix, left: Matrix) void {
     cdef.rlSetMatrixProjectionStereo(right, left);
 }
 
-/// Set eyes view offsets matrices for stereo rendering
 pub fn rlSetMatrixViewOffsetStereo(right: Matrix, left: Matrix) void {
     cdef.rlSetMatrixViewOffsetStereo(right, left);
 }
 
-/// Load and draw a cube
 pub fn rlLoadDrawCube() void {
     cdef.rlLoadDrawCube();
 }
 
-/// Load and draw a quad
 pub fn rlLoadDrawQuad() void {
     cdef.rlLoadDrawQuad();
 }

--- a/lib/rlgl.zig
+++ b/lib/rlgl.zig
@@ -188,34 +188,42 @@ pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR = @as(i32, 3);
 pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT = @as(i32, 4);
 pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2 = @as(i32, 5);
 
+/// Choose the current matrix to be transformed
 pub fn rlMatrixMode(mode: i32) void {
     cdef.rlMatrixMode(@as(c_int, mode));
 }
 
+/// Push the current matrix to stack
 pub fn rlPushMatrix() void {
     cdef.rlPushMatrix();
 }
 
+/// Pop latest inserted matrix from stack
 pub fn rlPopMatrix() void {
     cdef.rlPopMatrix();
 }
 
+/// Reset current matrix to identity matrix
 pub fn rlLoadIdentity() void {
     cdef.rlLoadIdentity();
 }
 
+/// Multiply the current matrix by a translation matrix
 pub fn rlTranslatef(x: f32, y: f32, z: f32) void {
     cdef.rlTranslatef(x, y, z);
 }
 
+/// Multiply the current matrix by a rotation matrix
 pub fn rlRotatef(angle: f32, x: f32, y: f32, z: f32) void {
     cdef.rlRotatef(angle, x, y, z);
 }
 
+/// Multiply the current matrix by a scaling matrix
 pub fn rlScalef(x: f32, y: f32, z: f32) void {
     cdef.rlScalef(x, y, z);
 }
 
+/// Multiply the current matrix by another matrix
 pub fn rlMultMatrixf(matf: []const f32) void {
     cdef.rlMultMatrixf(@as([*c]const f32, @ptrCast(matf)));
 }
@@ -228,578 +236,722 @@ pub fn rlOrtho(left: f64, right: f64, bottom: f64, top: f64, znear: f64, zfar: f
     cdef.rlOrtho(left, right, bottom, top, znear, zfar);
 }
 
+/// Set the viewport area
 pub fn rlViewport(x: i32, y: i32, width: i32, height: i32) void {
     cdef.rlViewport(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
+/// Set clip planes distances
 pub fn rlSetClipPlanes(near: f64, far: f64) void {
     cdef.rlSetClipPlanes(near, far);
 }
 
+/// Get cull plane distance near
 pub fn rlGetCullDistanceNear() f64 {
     return cdef.rlGetCullDistanceNear();
 }
 
+/// Get cull plane distance far
 pub fn rlGetCullDistanceFar() f64 {
     return cdef.rlGetCullDistanceFar();
 }
 
+/// Initialize drawing mode (how to organize vertex)
 pub fn rlBegin(mode: i32) void {
     cdef.rlBegin(@as(c_int, mode));
 }
 
+/// Finish vertex providing
 pub fn rlEnd() void {
     cdef.rlEnd();
 }
 
+/// Define one vertex (position) - 2 int
 pub fn rlVertex2i(x: i32, y: i32) void {
     cdef.rlVertex2i(@as(c_int, x), @as(c_int, y));
 }
 
+/// Define one vertex (position) - 2 float
 pub fn rlVertex2f(x: f32, y: f32) void {
     cdef.rlVertex2f(x, y);
 }
 
+/// Define one vertex (position) - 3 float
 pub fn rlVertex3f(x: f32, y: f32, z: f32) void {
     cdef.rlVertex3f(x, y, z);
 }
 
+/// Define one vertex (texture coordinate) - 2 float
 pub fn rlTexCoord2f(x: f32, y: f32) void {
     cdef.rlTexCoord2f(x, y);
 }
 
+/// Define one vertex (normal) - 3 float
 pub fn rlNormal3f(x: f32, y: f32, z: f32) void {
     cdef.rlNormal3f(x, y, z);
 }
 
+/// Define one vertex (color) - 4 byte
 pub fn rlColor4ub(r: u8, g: u8, b: u8, a: u8) void {
     cdef.rlColor4ub(r, g, b, a);
 }
 
+/// Define one vertex (color) - 3 float
 pub fn rlColor3f(x: f32, y: f32, z: f32) void {
     cdef.rlColor3f(x, y, z);
 }
 
+/// Define one vertex (color) - 4 float
 pub fn rlColor4f(x: f32, y: f32, z: f32, w: f32) void {
     cdef.rlColor4f(x, y, z, w);
 }
 
+/// Enable vertex array (VAO, if supported)
 pub fn rlEnableVertexArray(vaoId: u32) bool {
     return cdef.rlEnableVertexArray(@as(c_uint, vaoId));
 }
 
+/// Disable vertex array (VAO, if supported)
 pub fn rlDisableVertexArray() void {
     cdef.rlDisableVertexArray();
 }
 
+/// Enable vertex buffer (VBO)
 pub fn rlEnableVertexBuffer(id: u32) void {
     cdef.rlEnableVertexBuffer(@as(c_uint, id));
 }
 
+/// Disable vertex buffer (VBO)
 pub fn rlDisableVertexBuffer() void {
     cdef.rlDisableVertexBuffer();
 }
 
+/// Enable vertex buffer element (VBO element)
 pub fn rlEnableVertexBufferElement(id: u32) void {
     cdef.rlEnableVertexBufferElement(@as(c_uint, id));
 }
 
+/// Disable vertex buffer element (VBO element)
 pub fn rlDisableVertexBufferElement() void {
     cdef.rlDisableVertexBufferElement();
 }
 
+/// Enable vertex attribute index
 pub fn rlEnableVertexAttribute(index: u32) void {
     cdef.rlEnableVertexAttribute(@as(c_uint, index));
 }
 
+/// Disable vertex attribute index
 pub fn rlDisableVertexAttribute(index: u32) void {
     cdef.rlDisableVertexAttribute(@as(c_uint, index));
 }
 
+/// Enable attribute state pointer
 pub fn rlEnableStatePointer(vertexAttribType: i32, buffer: *anyopaque) void {
     cdef.rlEnableStatePointer(@as(c_int, vertexAttribType), buffer);
 }
 
+/// Disable attribute state pointer
 pub fn rlDisableStatePointer(vertexAttribType: i32) void {
     cdef.rlDisableStatePointer(@as(c_int, vertexAttribType));
 }
 
+/// Select and active a texture slot
 pub fn rlActiveTextureSlot(slot: i32) void {
     cdef.rlActiveTextureSlot(@as(c_int, slot));
 }
 
+/// Enable texture
 pub fn rlEnableTexture(id: u32) void {
     cdef.rlEnableTexture(@as(c_uint, id));
 }
 
+/// Disable texture
 pub fn rlDisableTexture() void {
     cdef.rlDisableTexture();
 }
 
+/// Enable texture cubemap
 pub fn rlEnableTextureCubemap(id: u32) void {
     cdef.rlEnableTextureCubemap(@as(c_uint, id));
 }
 
+/// Disable texture cubemap
 pub fn rlDisableTextureCubemap() void {
     cdef.rlDisableTextureCubemap();
 }
 
+/// Set texture parameters (filter, wrap)
 pub fn rlTextureParameters(id: u32, param: i32, value: i32) void {
     cdef.rlTextureParameters(@as(c_uint, id), @as(c_int, param), @as(c_int, value));
 }
 
+/// Set cubemap parameters (filter, wrap)
 pub fn rlCubemapParameters(id: u32, param: i32, value: i32) void {
     cdef.rlCubemapParameters(@as(c_uint, id), @as(c_int, param), @as(c_int, value));
 }
 
+/// Enable shader program
 pub fn rlEnableShader(id: u32) void {
     cdef.rlEnableShader(@as(c_uint, id));
 }
 
+/// Disable shader program
 pub fn rlDisableShader() void {
     cdef.rlDisableShader();
 }
 
+/// Enable render texture (fbo)
 pub fn rlEnableFramebuffer(id: u32) void {
     cdef.rlEnableFramebuffer(@as(c_uint, id));
 }
 
+/// Disable render texture (fbo), return to default framebuffer
 pub fn rlDisableFramebuffer() void {
     cdef.rlDisableFramebuffer();
 }
 
+/// Get the currently active render texture (fbo), 0 for default framebuffer
 pub fn rlGetActiveFramebuffer() u32 {
     return @as(u32, cdef.rlGetActiveFramebuffer());
 }
 
+/// Activate multiple draw color buffers
 pub fn rlActiveDrawBuffers(count: i32) void {
     cdef.rlActiveDrawBuffers(@as(c_int, count));
 }
 
+/// Blit active framebuffer to main framebuffer
 pub fn rlBlitFramebuffer(srcX: i32, srcY: i32, srcWidth: i32, srcHeight: i32, dstX: i32, dstY: i32, dstWidth: i32, dstHeight: i32, bufferMask: i32) void {
     cdef.rlBlitFramebuffer(@as(c_int, srcX), @as(c_int, srcY), @as(c_int, srcWidth), @as(c_int, srcHeight), @as(c_int, dstX), @as(c_int, dstY), @as(c_int, dstWidth), @as(c_int, dstHeight), @as(c_int, bufferMask));
 }
 
+/// Bind framebuffer (FBO)
 pub fn rlBindFramebuffer(target: u32, framebuffer: u32) void {
     cdef.rlBindFramebuffer(@as(c_uint, target), @as(c_uint, framebuffer));
 }
 
+/// Enable color blending
 pub fn rlEnableColorBlend() void {
     cdef.rlEnableColorBlend();
 }
 
+/// Disable color blending
 pub fn rlDisableColorBlend() void {
     cdef.rlDisableColorBlend();
 }
 
+/// Enable depth test
 pub fn rlEnableDepthTest() void {
     cdef.rlEnableDepthTest();
 }
 
+/// Disable depth test
 pub fn rlDisableDepthTest() void {
     cdef.rlDisableDepthTest();
 }
 
+/// Enable depth write
 pub fn rlEnableDepthMask() void {
     cdef.rlEnableDepthMask();
 }
 
+/// Disable depth write
 pub fn rlDisableDepthMask() void {
     cdef.rlDisableDepthMask();
 }
 
+/// Enable backface culling
 pub fn rlEnableBackfaceCulling() void {
     cdef.rlEnableBackfaceCulling();
 }
 
+/// Disable backface culling
 pub fn rlDisableBackfaceCulling() void {
     cdef.rlDisableBackfaceCulling();
 }
 
+/// Color mask control
 pub fn rlColorMask(r: bool, g: bool, b: bool, a: bool) void {
     cdef.rlColorMask(r, g, b, a);
 }
 
+/// Set face culling mode
 pub fn rlSetCullFace(mode: i32) void {
     cdef.rlSetCullFace(@as(c_int, mode));
 }
 
+/// Enable scissor test
 pub fn rlEnableScissorTest() void {
     cdef.rlEnableScissorTest();
 }
 
+/// Disable scissor test
 pub fn rlDisableScissorTest() void {
     cdef.rlDisableScissorTest();
 }
 
+/// Scissor test
 pub fn rlScissor(x: i32, y: i32, width: i32, height: i32) void {
     cdef.rlScissor(@as(c_int, x), @as(c_int, y), @as(c_int, width), @as(c_int, height));
 }
 
+/// Enable wire mode
 pub fn rlEnableWireMode() void {
     cdef.rlEnableWireMode();
 }
 
+/// Enable point mode
 pub fn rlEnablePointMode() void {
     cdef.rlEnablePointMode();
 }
 
+/// Disable wire mode ( and point ) maybe rename
 pub fn rlDisableWireMode() void {
     cdef.rlDisableWireMode();
 }
 
+/// Set the line drawing width
 pub fn rlSetLineWidth(width: f32) void {
     cdef.rlSetLineWidth(width);
 }
 
+/// Get the line drawing width
 pub fn rlGetLineWidth() f32 {
     return cdef.rlGetLineWidth();
 }
 
+/// Enable line aliasing
 pub fn rlEnableSmoothLines() void {
     cdef.rlEnableSmoothLines();
 }
 
+/// Disable line aliasing
 pub fn rlDisableSmoothLines() void {
     cdef.rlDisableSmoothLines();
 }
 
+/// Enable stereo rendering
 pub fn rlEnableStereoRender() void {
     cdef.rlEnableStereoRender();
 }
 
+/// Disable stereo rendering
 pub fn rlDisableStereoRender() void {
     cdef.rlDisableStereoRender();
 }
 
+/// Check if stereo render is enabled
 pub fn rlIsStereoRenderEnabled() bool {
     return cdef.rlIsStereoRenderEnabled();
 }
 
+/// Clear color buffer with color
 pub fn rlClearColor(r: u8, g: u8, b: u8, a: u8) void {
     cdef.rlClearColor(r, g, b, a);
 }
 
+/// Clear used screen buffers (color and depth)
 pub fn rlClearScreenBuffers() void {
     cdef.rlClearScreenBuffers();
 }
 
+/// Check and log OpenGL error codes
 pub fn rlCheckErrors() void {
     cdef.rlCheckErrors();
 }
 
+/// Set blending mode
 pub fn rlSetBlendMode(mode: i32) void {
     cdef.rlSetBlendMode(@as(c_int, mode));
 }
 
+/// Set blending mode factor and equation (using OpenGL factors)
 pub fn rlSetBlendFactors(glSrcFactor: i32, glDstFactor: i32, glEquation: i32) void {
     cdef.rlSetBlendFactors(@as(c_int, glSrcFactor), @as(c_int, glDstFactor), @as(c_int, glEquation));
 }
 
+/// Set blending mode factors and equations separately (using OpenGL factors)
 pub fn rlSetBlendFactorsSeparate(glSrcRGB: i32, glDstRGB: i32, glSrcAlpha: i32, glDstAlpha: i32, glEqRGB: i32, glEqAlpha: i32) void {
     cdef.rlSetBlendFactorsSeparate(@as(c_int, glSrcRGB), @as(c_int, glDstRGB), @as(c_int, glSrcAlpha), @as(c_int, glDstAlpha), @as(c_int, glEqRGB), @as(c_int, glEqAlpha));
 }
 
+/// Initialize rlgl (buffers, shaders, textures, states)
 pub fn rlglInit(width: i32, height: i32) void {
     cdef.rlglInit(@as(c_int, width), @as(c_int, height));
 }
 
+/// De-initialize rlgl (buffers, shaders, textures)
 pub fn rlglClose() void {
     cdef.rlglClose();
 }
 
+/// Load OpenGL extensions (loader function required)
 pub fn rlLoadExtensions(loader: *anyopaque) void {
     cdef.rlLoadExtensions(loader);
 }
 
+/// Get current OpenGL version
 pub fn rlGetVersion() i32 {
     return @as(i32, cdef.rlGetVersion());
 }
 
+/// Set current framebuffer width
 pub fn rlSetFramebufferWidth(width: i32) void {
     cdef.rlSetFramebufferWidth(@as(c_int, width));
 }
 
+/// Get default framebuffer width
 pub fn rlGetFramebufferWidth() i32 {
     return @as(i32, cdef.rlGetFramebufferWidth());
 }
 
+/// Set current framebuffer height
 pub fn rlSetFramebufferHeight(height: i32) void {
     cdef.rlSetFramebufferHeight(@as(c_int, height));
 }
 
+/// Get default framebuffer height
 pub fn rlGetFramebufferHeight() i32 {
     return @as(i32, cdef.rlGetFramebufferHeight());
 }
 
+/// Get default texture id
 pub fn rlGetTextureIdDefault() u32 {
     return @as(u32, cdef.rlGetTextureIdDefault());
 }
 
+/// Get default shader id
 pub fn rlGetShaderIdDefault() u32 {
     return @as(u32, cdef.rlGetShaderIdDefault());
 }
 
+/// Load a render batch system
 pub fn rlLoadRenderBatch(numBuffers: i32, bufferElements: i32) rlRenderBatch {
     return cdef.rlLoadRenderBatch(@as(c_int, numBuffers), @as(c_int, bufferElements));
 }
 
+/// Unload render batch system
 pub fn rlUnloadRenderBatch(batch: rlRenderBatch) void {
     cdef.rlUnloadRenderBatch(batch);
 }
 
+/// Draw render batch data (Update->Draw->Reset)
 pub fn rlDrawRenderBatch(batch: *rlRenderBatch) void {
     cdef.rlDrawRenderBatch(@as([*c]rlRenderBatch, @ptrCast(batch)));
 }
 
+/// Set the active render batch for rlgl (NULL for default internal)
 pub fn rlSetRenderBatchActive(batch: *rlRenderBatch) void {
     cdef.rlSetRenderBatchActive(@as([*c]rlRenderBatch, @ptrCast(batch)));
 }
 
+/// Update and draw internal render batch
 pub fn rlDrawRenderBatchActive() void {
     cdef.rlDrawRenderBatchActive();
 }
 
+/// Check internal buffer overflow for a given number of vertex
 pub fn rlCheckRenderBatchLimit(vCount: i32) bool {
     return cdef.rlCheckRenderBatchLimit(@as(c_int, vCount));
 }
 
+/// Set current texture for render batch and check buffers limits
 pub fn rlSetTexture(id: u32) void {
     cdef.rlSetTexture(@as(c_uint, id));
 }
 
+/// Load vertex array (vao) if supported
 pub fn rlLoadVertexArray() u32 {
     return @as(u32, cdef.rlLoadVertexArray());
 }
 
+/// Load a vertex buffer object
 pub fn rlLoadVertexBuffer(buffer: *const anyopaque, size: i32, dynamic: bool) u32 {
     return @as(u32, cdef.rlLoadVertexBuffer(buffer, @as(c_int, size), dynamic));
 }
 
+/// Load vertex buffer elements object
 pub fn rlLoadVertexBufferElement(buffer: *const anyopaque, size: i32, dynamic: bool) u32 {
     return @as(u32, cdef.rlLoadVertexBufferElement(buffer, @as(c_int, size), dynamic));
 }
 
+/// Update vertex buffer object data on GPU buffer
 pub fn rlUpdateVertexBuffer(bufferId: u32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.rlUpdateVertexBuffer(@as(c_uint, bufferId), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
+/// Update vertex buffer elements data on GPU buffer
 pub fn rlUpdateVertexBufferElements(id: u32, data: *const anyopaque, dataSize: i32, offset: i32) void {
     cdef.rlUpdateVertexBufferElements(@as(c_uint, id), data, @as(c_int, dataSize), @as(c_int, offset));
 }
 
+/// Unload vertex array (vao)
 pub fn rlUnloadVertexArray(vaoId: u32) void {
     cdef.rlUnloadVertexArray(@as(c_uint, vaoId));
 }
 
+/// Unload vertex buffer object
 pub fn rlUnloadVertexBuffer(vboId: u32) void {
     cdef.rlUnloadVertexBuffer(@as(c_uint, vboId));
 }
 
+/// Set vertex attribute data configuration
 pub fn rlSetVertexAttribute(index: u32, compSize: i32, ty: i32, normalized: bool, stride: i32, offset: i32) void {
     cdef.rlSetVertexAttribute(@as(c_uint, index), @as(c_int, compSize), @as(c_int, ty), normalized, @as(c_int, stride), @as(c_int, offset));
 }
 
+/// Set vertex attribute data divisor
 pub fn rlSetVertexAttributeDivisor(index: u32, divisor: i32) void {
     cdef.rlSetVertexAttributeDivisor(@as(c_uint, index), @as(c_int, divisor));
 }
 
+/// Set vertex attribute default value, when attribute to provided
 pub fn rlSetVertexAttributeDefault(locIndex: i32, value: *const anyopaque, attribType: i32, count: i32) void {
     cdef.rlSetVertexAttributeDefault(@as(c_int, locIndex), value, @as(c_int, attribType), @as(c_int, count));
 }
 
+/// Draw vertex array (currently active vao)
 pub fn rlDrawVertexArray(offset: i32, count: i32) void {
     cdef.rlDrawVertexArray(@as(c_int, offset), @as(c_int, count));
 }
 
+/// Draw vertex array elements
 pub fn rlDrawVertexArrayElements(offset: i32, count: i32, buffer: ?*const anyopaque) void {
     cdef.rlDrawVertexArrayElements(@as(c_int, offset), @as(c_int, count), buffer);
 }
 
+/// Draw vertex array (currently active vao) with instancing
 pub fn rlDrawVertexArrayInstanced(offset: i32, count: i32, instances: i32) void {
     cdef.rlDrawVertexArrayInstanced(@as(c_int, offset), @as(c_int, count), @as(c_int, instances));
 }
 
+/// Draw vertex array elements with instancing
 pub fn rlDrawVertexArrayElementsInstanced(offset: i32, count: i32, buffer: ?*const anyopaque, instances: i32) void {
     cdef.rlDrawVertexArrayElementsInstanced(@as(c_int, offset), @as(c_int, count), buffer, @as(c_int, instances));
 }
 
+/// Load texture data
 pub fn rlLoadTexture(data: *const anyopaque, width: i32, height: i32, format: i32, mipmapCount: i32) u32 {
     return @as(u32, cdef.rlLoadTexture(data, @as(c_int, width), @as(c_int, height), @as(c_int, format), @as(c_int, mipmapCount)));
 }
 
+/// Load depth texture/renderbuffer (to be attached to fbo)
 pub fn rlLoadTextureDepth(width: i32, height: i32, useRenderBuffer: bool) u32 {
     return @as(u32, cdef.rlLoadTextureDepth(@as(c_int, width), @as(c_int, height), useRenderBuffer));
 }
 
+/// Load texture cubemap data
 pub fn rlLoadTextureCubemap(data: *const anyopaque, size: i32, format: i32) u32 {
     return @as(u32, cdef.rlLoadTextureCubemap(data, @as(c_int, size), @as(c_int, format)));
 }
 
+/// Update texture with new data on GPU
 pub fn rlUpdateTexture(id: u32, offsetX: i32, offsetY: i32, width: i32, height: i32, format: i32, data: *const anyopaque) void {
     cdef.rlUpdateTexture(@as(c_uint, id), @as(c_int, offsetX), @as(c_int, offsetY), @as(c_int, width), @as(c_int, height), @as(c_int, format), data);
 }
 
+/// Get OpenGL internal formats
 pub fn rlGetGlTextureFormats(format: i32, glInternalFormat: *u32, glFormat: *u32, glType: *u32) void {
     cdef.rlGetGlTextureFormats(@as(c_int, format), @as([*c]c_uint, @ptrCast(glInternalFormat)), @as([*c]c_uint, @ptrCast(glFormat)), @as([*c]c_uint, @ptrCast(glType)));
 }
 
+/// Get name string for pixel format
 pub fn rlGetPixelFormatName(format: u32) [:0]const u8 {
     return std.mem.span(cdef.rlGetPixelFormatName(@as(c_uint, format)));
 }
 
+/// Unload texture from GPU memory
 pub fn rlUnloadTexture(id: u32) void {
     cdef.rlUnloadTexture(@as(c_uint, id));
 }
 
+/// Generate mipmap data for selected texture
 pub fn rlGenTextureMipmaps(id: u32, width: i32, height: i32, format: i32, mipmaps: *i32) void {
     cdef.rlGenTextureMipmaps(@as(c_uint, id), @as(c_int, width), @as(c_int, height), @as(c_int, format), @as([*c]c_int, @ptrCast(mipmaps)));
 }
 
+/// Read texture pixel data
 pub fn rlReadTexturePixels(id: u32, width: i32, height: i32, format: i32) *anyopaque {
     return cdef.rlReadTexturePixels(@as(c_uint, id), @as(c_int, width), @as(c_int, height), @as(c_int, format));
 }
 
+/// Read screen pixel data (color buffer)
 pub fn rlReadScreenPixels(width: i32, height: i32) [:0]u8 {
     return std.mem.span(cdef.rlReadScreenPixels(@as(c_int, width), @as(c_int, height)));
 }
 
+/// Load an empty framebuffer
 pub fn rlLoadFramebuffer() u32 {
     return @as(u32, cdef.rlLoadFramebuffer());
 }
 
+/// Attach texture/renderbuffer to a framebuffer
 pub fn rlFramebufferAttach(fboId: u32, texId: u32, attachType: i32, texType: i32, mipLevel: i32) void {
     cdef.rlFramebufferAttach(@as(c_uint, fboId), @as(c_uint, texId), @as(c_int, attachType), @as(c_int, texType), @as(c_int, mipLevel));
 }
 
+/// Verify framebuffer is complete
 pub fn rlFramebufferComplete(id: u32) bool {
     return cdef.rlFramebufferComplete(@as(c_uint, id));
 }
 
+/// Delete framebuffer from GPU
 pub fn rlUnloadFramebuffer(id: u32) void {
     cdef.rlUnloadFramebuffer(@as(c_uint, id));
 }
 
+/// Load shader from code strings
 pub fn rlLoadShaderCode(vsCode: [:0]const u8, fsCode: [:0]const u8) u32 {
     return @as(u32, cdef.rlLoadShaderCode(@as([*c]const u8, @ptrCast(vsCode)), @as([*c]const u8, @ptrCast(fsCode))));
 }
 
+/// Compile custom shader and return shader id (type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER)
 pub fn rlCompileShader(shaderCode: [:0]const u8, ty: i32) u32 {
     return @as(u32, cdef.rlCompileShader(@as([*c]const u8, @ptrCast(shaderCode)), @as(c_int, ty)));
 }
 
+/// Load custom shader program
 pub fn rlLoadShaderProgram(vShaderId: u32, fShaderId: u32) u32 {
     return @as(u32, cdef.rlLoadShaderProgram(@as(c_uint, vShaderId), @as(c_uint, fShaderId)));
 }
 
+/// Unload shader program
 pub fn rlUnloadShaderProgram(id: u32) void {
     cdef.rlUnloadShaderProgram(@as(c_uint, id));
 }
 
+/// Get shader location uniform
 pub fn rlGetLocationUniform(shaderId: u32, uniformName: [:0]const u8) i32 {
     return @as(i32, cdef.rlGetLocationUniform(@as(c_uint, shaderId), @as([*c]const u8, @ptrCast(uniformName))));
 }
 
+/// Get shader location attribute
 pub fn rlGetLocationAttrib(shaderId: u32, attribName: [:0]const u8) i32 {
     return @as(i32, cdef.rlGetLocationAttrib(@as(c_uint, shaderId), @as([*c]const u8, @ptrCast(attribName))));
 }
 
+/// Set shader value uniform
 pub fn rlSetUniform(locIndex: i32, value: *const anyopaque, uniformType: i32, count: i32) void {
     cdef.rlSetUniform(@as(c_int, locIndex), value, @as(c_int, uniformType), @as(c_int, count));
 }
 
+/// Set shader value matrix
 pub fn rlSetUniformMatrix(locIndex: i32, mat: Matrix) void {
     cdef.rlSetUniformMatrix(@as(c_int, locIndex), mat);
 }
 
+/// Set shader value sampler
 pub fn rlSetUniformSampler(locIndex: i32, textureId: u32) void {
     cdef.rlSetUniformSampler(@as(c_int, locIndex), @as(c_uint, textureId));
 }
 
+/// Set shader currently active (id and locations)
 pub fn rlSetShader(id: u32, locs: []i32) void {
     cdef.rlSetShader(@as(c_uint, id), @as([*c]c_int, @ptrCast(locs)));
 }
 
+/// Load compute shader program
 pub fn rlLoadComputeShaderProgram(shaderId: u32) u32 {
     return @as(u32, cdef.rlLoadComputeShaderProgram(@as(c_uint, shaderId)));
 }
 
+/// Dispatch compute shader (equivalent to *draw* for graphics pipeline)
 pub fn rlComputeShaderDispatch(groupX: u32, groupY: u32, groupZ: u32) void {
     cdef.rlComputeShaderDispatch(@as(c_uint, groupX), @as(c_uint, groupY), @as(c_uint, groupZ));
 }
 
+/// Load shader storage buffer object (SSBO)
 pub fn rlLoadShaderBuffer(size: u32, data: *const anyopaque, usageHint: i32) u32 {
     return @as(u32, cdef.rlLoadShaderBuffer(@as(c_uint, size), data, @as(c_int, usageHint)));
 }
 
+/// Unload shader storage buffer object (SSBO)
 pub fn rlUnloadShaderBuffer(ssboId: u32) void {
     cdef.rlUnloadShaderBuffer(@as(c_uint, ssboId));
 }
 
+/// Update SSBO buffer data
 pub fn rlUpdateShaderBuffer(id: u32, data: *const anyopaque, dataSize: u32, offset: u32) void {
     cdef.rlUpdateShaderBuffer(@as(c_uint, id), data, @as(c_uint, dataSize), @as(c_uint, offset));
 }
 
+/// Bind SSBO buffer
 pub fn rlBindShaderBuffer(id: u32, index: u32) void {
     cdef.rlBindShaderBuffer(@as(c_uint, id), @as(c_uint, index));
 }
 
+/// Read SSBO buffer data (GPU->CPU)
 pub fn rlReadShaderBuffer(id: u32, dest: *anyopaque, count: u32, offset: u32) void {
     cdef.rlReadShaderBuffer(@as(c_uint, id), dest, @as(c_uint, count), @as(c_uint, offset));
 }
 
+/// Copy SSBO data between buffers
 pub fn rlCopyShaderBuffer(destId: u32, srcId: u32, destOffset: u32, srcOffset: u32, count: u32) void {
     cdef.rlCopyShaderBuffer(@as(c_uint, destId), @as(c_uint, srcId), @as(c_uint, destOffset), @as(c_uint, srcOffset), @as(c_uint, count));
 }
 
+/// Get SSBO buffer size
 pub fn rlGetShaderBufferSize(id: u32) u32 {
     return @as(u32, cdef.rlGetShaderBufferSize(@as(c_uint, id)));
 }
 
+/// Bind image texture
 pub fn rlBindImageTexture(id: u32, index: u32, format: i32, readonly: bool) void {
     cdef.rlBindImageTexture(@as(c_uint, id), @as(c_uint, index), @as(c_int, format), readonly);
 }
 
+/// Get internal modelview matrix
 pub fn rlGetMatrixModelview() Matrix {
     return cdef.rlGetMatrixModelview();
 }
 
+/// Get internal projection matrix
 pub fn rlGetMatrixProjection() Matrix {
     return cdef.rlGetMatrixProjection();
 }
 
+/// Get internal accumulated transform matrix
 pub fn rlGetMatrixTransform() Matrix {
     return cdef.rlGetMatrixTransform();
 }
 
+/// Get internal projection matrix for stereo render (selected eye)
 pub fn rlGetMatrixProjectionStereo(eye: i32) Matrix {
     return cdef.rlGetMatrixProjectionStereo(@as(c_int, eye));
 }
 
+/// Get internal view offset matrix for stereo render (selected eye)
 pub fn rlGetMatrixViewOffsetStereo(eye: i32) Matrix {
     return cdef.rlGetMatrixViewOffsetStereo(@as(c_int, eye));
 }
 
+/// Set a custom projection matrix (replaces internal projection matrix)
 pub fn rlSetMatrixProjection(proj: Matrix) void {
     cdef.rlSetMatrixProjection(proj);
 }
 
+/// Set a custom modelview matrix (replaces internal modelview matrix)
 pub fn rlSetMatrixModelview(view: Matrix) void {
     cdef.rlSetMatrixModelview(view);
 }
 
+/// Set eyes projection matrices for stereo rendering
 pub fn rlSetMatrixProjectionStereo(right: Matrix, left: Matrix) void {
     cdef.rlSetMatrixProjectionStereo(right, left);
 }
 
+/// Set eyes view offsets matrices for stereo rendering
 pub fn rlSetMatrixViewOffsetStereo(right: Matrix, left: Matrix) void {
     cdef.rlSetMatrixViewOffsetStereo(right, left);
 }
 
+/// Load and draw a cube
 pub fn rlLoadDrawCube() void {
     cdef.rlLoadDrawCube();
 }
 
+/// Load and draw a quad
 pub fn rlLoadDrawQuad() void {
     cdef.rlLoadDrawQuad();
 }


### PR DESCRIPTION
This is a bare bones implementation of making use of Raylibs inline comments for documenting functions.

This implementation *is missing some important things*. For example fields of structs (like Vector2's) don't get doc comments as I cannot understand the python file and where it does this. Some of the comments have type names lying in them or function names which do not get ziggified. Even though this is the case I don't think this PR is harmful to merge.