### PR TITLE
fix setMouseCursor() and setTextureWrap() enum types

### DIFF
--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -147,6 +147,28 @@ def fix_pointer(name: str, t: str):
     return name, t
 
 
+_fix_enums_data = [
+    # arg_name,     new_type,                func_name_regex
+    ("key",         "KeyboardKey",           r".*"),
+    ("mode",        "CameraMode",            r"UpdateCamera"),
+    ("mode",        "BlendMode",             r"BeginBlendMode"),
+    ("gesture",     "Gesture",               r".*"),
+    ("logLevel",    "TraceLogLevel",         r".*"),
+    ("ty",          "FontType",              r".*"),
+    ("uniformType", "ShaderUniformDataType", r".*"),
+    ("cursor",      "MouseCursor",           r".*"),
+    ("format",      "PixelFormat",           r".*"),
+    ("newFormat",   "PixelFormat",           r".*"),
+    ("layout",      "CubemapLayout",         r".*"),
+    ("mapType",     "MaterialMapIndex",      r".*"),
+    ("filter",      "TextureFilter",         r"SetTextureFilter"),
+    ("wrap",        "TextureWrap",           r"SetTextureWrap"),
+    ("flags",       "ConfigFlags",           r"SetWindowState|ClearWindowState|SetConfigFlags"),
+    ("flag",        "ConfigFlags",           r"IsWindowState"),
+    ("flags",       "Gesture",               r"SetGesturesEnabled"),
+    ("button",      "GamepadButton",         r".*GamepadButton.*"),
+    ("button",      "MouseButton",           r".*MouseButton.*"),
+]
 def fix_enums(arg_name, arg_type, func_name):
     if func_name.startswith("rl"):
         return arg_type
@@ -154,47 +176,9 @@ def fix_enums(arg_name, arg_type, func_name):
     # Hacking specific enums in here.
     # Raylib doesn't use the enums but rather the resulting ints.
     if arg_type == "int" or arg_type == "unsigned int":
-        if arg_name == "key":
-            arg_type = "KeyboardKey"
-        elif arg_name == "button":
-            if "Gamepad" in func_name:
-                arg_type = "GamepadButton"
-            else:
-                arg_type = "MouseButton"
-        elif arg_name == "mode":
-            if func_name == "UpdateCamera":
-                arg_type = "CameraMode"
-            elif func_name == "BeginBlendMode":
-                arg_type = "BlendMode"
-        elif arg_name == "gesture":
-            arg_type = "Gesture"
-        elif arg_name == "flags" or arg_name == "flag":
-            if func_name in [
-                    "SetWindowState", "ClearWindowState", "SetConfigFlags", "IsWindowState"
-            ]:
-                arg_type = "ConfigFlags"
-            elif func_name == "SetGesturesEnabled":
-                arg_type = "Gesture"
-        elif arg_name == "logLevel":
-            arg_type = "TraceLogLevel"
-        elif arg_name == "ty":
-            arg_type = "FontType"
-        elif arg_name == "uniformType":
-            arg_type = "ShaderUniformDataType"
-        elif arg_name == "cursor":
-            arg_type = "MouseCursor"
-        elif arg_name == "newFormat":
-            arg_type = "PixelFormat"
-        elif arg_name == "layout":
-            arg_type = "CubemapLayout"
-        elif arg_name == "filter" and func_name == "SetTextureFilter":
-            arg_type = "TextureFilter"
-        elif arg_name == "wrap" and func_name == "SetTextureWrap":
-            arg_type = "TextureWrap"
-        elif arg_name == "format":
-            arg_type = "PixelFormat"
-        elif arg_name == "mapType":
-            arg_type = "MaterialMapIndex"
+        for target_arg_name,new_type,func_name_regex in _fix_enums_data:
+            if arg_name==target_arg_name and re.fullmatch(func_name_regex,func_name):
+                return new_type
     return arg_type
 
 

--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -181,7 +181,7 @@ def fix_enums(arg_name, arg_type, func_name):
             arg_type = "FontType"
         elif arg_name == "uniformType":
             arg_type = "ShaderUniformDataType"
-        elif arg_name == "Cursor":
+        elif arg_name == "cursor":
             arg_type = "MouseCursor"
         elif arg_name == "newFormat":
             arg_type = "PixelFormat"
@@ -189,7 +189,7 @@ def fix_enums(arg_name, arg_type, func_name):
             arg_type = "CubemapLayout"
         elif arg_name == "filter" and func_name == "SetTextureFilter":
             arg_type = "TextureFilter"
-        elif arg_name == "TextureWrap":
+        elif arg_name == "wrap" and func_name == "SetTextureWrap":
             arg_type = "TextureWrap"
         elif arg_name == "format":
             arg_type = "PixelFormat"

--- a/lib/preludes/raylib-prelude.zig
+++ b/lib/preludes/raylib-prelude.zig
@@ -1281,7 +1281,7 @@ pub const Font = extern struct {
         return rl.loadFont(fileName);
     }
 
-    /// Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
+    /// Load font from file with extended parameters, use null for fontChars to load the default character set
     pub fn initEx(fileName: [*:0]const u8, fontSize: i32, fontChars: ?[]i32) Font {
         return rl.loadFontEx(fileName, fontSize, fontChars);
     }
@@ -1325,7 +1325,7 @@ pub const Camera3D = extern struct {
     }
 
     /// Update camera position for selected mode
-    pub fn update(self: *Camera3D, mode: rl.CameraMode) void {
+    pub fn update(self: *Camera3D, mode: CameraMode) void {
         rl.updateCamera(self, mode);
     }
 
@@ -2095,8 +2095,7 @@ pub fn loadImagePalette(image: Image, maxPaletteSize: i32) RaylibError![]Color {
     return res;
 }
 
-/// Load font from file with extended parameters, use null for codepoints and 0
-/// for codepointCount to load the default character set
+/// Load font from file with extended parameters, use null for fontChars to load the default character set
 pub fn loadFontEx(fileName: [*:0]const u8, fontSize: i32, fontChars: ?[]i32) Font {
     var fontCharsFinal = @as([*c]c_int, 0);
     var fontCharsLen: c_int = @as(c_int, 0);

--- a/lib/raylib-ext.zig
+++ b/lib/raylib-ext.zig
@@ -188,7 +188,7 @@ pub extern "c" fn SetMouseOffset(offsetX: c_int, offsetY: c_int) void;
 pub extern "c" fn SetMouseScale(scaleX: f32, scaleY: f32) void;
 pub extern "c" fn GetMouseWheelMove() f32;
 pub extern "c" fn GetMouseWheelMoveV() rl.Vector2;
-pub extern "c" fn SetMouseCursor(cursor: c_int) void;
+pub extern "c" fn SetMouseCursor(cursor: rl.MouseCursor) void;
 pub extern "c" fn GetTouchX() c_int;
 pub extern "c" fn GetTouchY() c_int;
 pub extern "c" fn GetTouchPosition(index: c_int) rl.Vector2;
@@ -355,7 +355,7 @@ pub extern "c" fn UpdateTexture(texture: rl.Texture2D, pixels: *const anyopaque)
 pub extern "c" fn UpdateTextureRec(texture: rl.Texture2D, rec: rl.Rectangle, pixels: *const anyopaque) void;
 pub extern "c" fn GenTextureMipmaps(texture: [*c]rl.Texture2D) void;
 pub extern "c" fn SetTextureFilter(texture: rl.Texture2D, filter: rl.TextureFilter) void;
-pub extern "c" fn SetTextureWrap(texture: rl.Texture2D, wrap: c_int) void;
+pub extern "c" fn SetTextureWrap(texture: rl.Texture2D, wrap: rl.TextureWrap) void;
 pub extern "c" fn DrawTexture(texture: rl.Texture2D, posX: c_int, posY: c_int, tint: rl.Color) void;
 pub extern "c" fn DrawTextureV(texture: rl.Texture2D, position: rl.Vector2, tint: rl.Color) void;
 pub extern "c" fn DrawTextureEx(texture: rl.Texture2D, position: rl.Vector2, rotation: f32, scale: f32, tint: rl.Color) void;

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -1281,7 +1281,7 @@ pub const Font = extern struct {
         return rl.loadFont(fileName);
     }
 
-    /// Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
+    /// Load font from file with extended parameters, use null for fontChars to load the default character set
     pub fn initEx(fileName: [*:0]const u8, fontSize: i32, fontChars: ?[]i32) Font {
         return rl.loadFontEx(fileName, fontSize, fontChars);
     }
@@ -1325,7 +1325,7 @@ pub const Camera3D = extern struct {
     }
 
     /// Update camera position for selected mode
-    pub fn update(self: *Camera3D, mode: rl.CameraMode) void {
+    pub fn update(self: *Camera3D, mode: CameraMode) void {
         rl.updateCamera(self, mode);
     }
 
@@ -2095,8 +2095,7 @@ pub fn loadImagePalette(image: Image, maxPaletteSize: i32) RaylibError![]Color {
     return res;
 }
 
-/// Load font from file with extended parameters, use null for codepoints and 0
-/// for codepointCount to load the default character set
+/// Load font from file with extended parameters, use null for fontChars to load the default character set
 pub fn loadFontEx(fileName: [*:0]const u8, fontSize: i32, fontChars: ?[]i32) Font {
     var fontCharsFinal = @as([*c]c_int, 0);
     var fontCharsLen: c_int = @as(c_int, 0);

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -3173,8 +3173,8 @@ pub fn getMouseWheelMoveV() Vector2 {
 }
 
 /// Set mouse cursor
-pub fn setMouseCursor(cursor: i32) void {
-    cdef.SetMouseCursor(@as(c_int, cursor));
+pub fn setMouseCursor(cursor: MouseCursor) void {
+    cdef.SetMouseCursor(cursor);
 }
 
 /// Get touch position X for touch point 0 (relative to screen size)
@@ -3968,8 +3968,8 @@ pub fn setTextureFilter(texture: Texture2D, filter: TextureFilter) void {
 }
 
 /// Set texture wrapping mode
-pub fn setTextureWrap(texture: Texture2D, wrap: i32) void {
-    cdef.SetTextureWrap(texture, @as(c_int, wrap));
+pub fn setTextureWrap(texture: Texture2D, wrap: TextureWrap) void {
+    cdef.SetTextureWrap(texture, wrap);
 }
 
 /// Draw a Texture2D


### PR DESCRIPTION
The main change here is
```diff
- pub fn setMouseCursor(cursor: i32) void {
-     cdef.SetMouseCursor(@as(c_int, cursor));
+ pub fn setMouseCursor(cursor: MouseCursor) void {
+    cdef.SetMouseCursor(cursor);
}
```
and similar for `setTextureWrap()`. These are bugfixes, due to typos in generate_functions.py

There's some other tidying I did as well. In particular, I overhauled `fix_enums()` to hopefully make it easier to avoid these sorts of problems in the future. It makes the logic a bit more abstract -- for good reason IMO, but let me know if you don't want it.