### PR TITLE
fix zig fetch command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ want to run an example, say `basic_window` run `zig build basic_window`
 Download and add raylib-zig as a dependency by running the following command in your project root:
 
 ```
-zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz
+zig fetch --save git+https://github.com/Not-Nik/raylib-zig#devel
 ```
 
 Then add raylib-zig as a dependency and import its modules and artifact in your `build.zig`:

--- a/project_setup.ps1
+++ b/project_setup.ps1
@@ -58,21 +58,17 @@ pub fn build(b: *std.Build) !void {
 
 New-Item -Name "build.zig" -ItemType "file" -Value $BUILD_DOT_ZIG -Force
 
-$HASH = $(zig fetch https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz)
-
 $ZON_FILE = @"
 .{
     .name = "$PROJECT_NAME",
     .version = "0.0.1",
     .dependencies = .{
-        .@"raylib-zig" = .{
-            .url = "https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz",
-            .hash = "$HASH",
-        },
     },
     .paths = .{""},
 }
 "@
+
+zig fetch --save git+https://github.com/Not-Nik/raylib-zig#devel
 
 New-Item -Name "build.zig.zon" -ItemType "file" -Value $ZON_FILE -Force
 

--- a/project_setup.sh
+++ b/project_setup.sh
@@ -54,19 +54,15 @@ pub fn build(b: *std.Build) !void {
     b.installArtifact(exe);
 }' >> build.zig
 
-HASH=$(zig fetch https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz)
-
 echo '.{
     .name = "'$PROJECT_NAME'",
     .version = "0.0.1",
     .dependencies = .{
-        .@"raylib-zig" = .{
-            .url = "https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz",
-            .hash = "'$HASH'",
-        },
     },
     .paths = .{""},
 }' >> build.zig.zon
+
+zig fetch --save git+https://github.com/Not-Nik/raylib-zig#devel
 
 mkdir src
 cp ../examples/core/basic_window.zig src/main.zig


### PR DESCRIPTION
All URLs within build.zig.zon files must point to archives that never change.  However, the zig fetch command in the README.md adds a URL that points to the `devel` git branch whose content changes whenever the `devel` branch is updated.

I've updated the README to instruct users to first pick a git SHA to reference if they want to add this project to their build.zig.zon file, then use that sha in their URL.