### PR TITLE
Update the readme with dependency pinning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,14 @@ want to run an example, say `basic_window` run `zig build basic_window`
 
 Download and add raylib-zig as a dependency by running the following command in your project root:
 
-```
+```sh
 zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz
+```
+
+or to pin this dependency and avoid a possible disruption after the next release, you can use a url with the git sha:
+
+```sh
+zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/58df62807f62bef1db79538d04b37b9f79909d0a.tar.gz
 ```
 
 Then add raylib-zig as a dependency and import its modules and artifact in your `build.zig`:


### PR DESCRIPTION
Following the instructions on [zigistry](https://zigistry.dev/packages/Not-Nik/raylib-zig) I hit a snag.

Installing from the latest tag, the example at the top of the page, results in an error:

```sh
zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/refs/tags/v5.0.tar.gz
zig build run
...
/build.zig:2:21: error: no module named 'raylib-zig' available within module root.@build
const rlz = @import("raylib-zig");
                    ^~~~~~~~~~~~
...
```
Installing from the devel branch avoids that error but results in another error after a new release and cloning my repository on a different machine:

```sh
zig fetch --save https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz
# some time later
zig build run
...
error: hash mismatch: manifest declares 1220608d53a1e0e295f8367be3aa7b1439d044af1551ae64cf5ae6ce9edb05858e73 but the fetched package has 1220df9aa89d657f5dca24ab0ac3d187f7a992a4d27461fd9e76e934bf0670ca9a90
            .hash = "1220608d53a1e0e295f8367be3aa7b1439d044af1551ae64cf5ae6ce9edb05858e73",
```

It took me a little time to realize that instead of begging for you to cut a release, I can just build a url with the git sha desired, and the problem was solved.  I added instructions to the readme in this PR for the next person in my situation.