### PR TITLE
Automatically include Emscripten headers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -318,7 +318,7 @@ pub fn build(b: *std.Build) !void {
 
     for (examples) |ex| {
         if (target.query.os_tag == .emscripten) {
-            const exe_lib = emcc.compileForEmscripten(b, ex.name, ex.path, target, optimize);
+            const exe_lib = try emcc.compileForEmscripten(b, ex.name, ex.path, target, optimize);
             exe_lib.root_module.addImport("raylib", raylib);
             exe_lib.root_module.addImport("raygui", raygui);
             const raylib_lib = getRaylib(b, target, optimize, options);

--- a/emcc.zig
+++ b/emcc.zig
@@ -39,7 +39,7 @@ pub fn compileForEmscripten(
     root_source_file: []const u8,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.Mode,
-) *std.Build.Step.Compile {
+) !*std.Build.Step.Compile {
     // TODO: It might be a good idea to create a custom compile step, that does
     // both the compile to static library and the link with emcc by overidding
     // the make function of the step. However it might also be a bad idea since
@@ -53,7 +53,7 @@ pub fn compileForEmscripten(
         .optimize = optimize,
     });
 
-    const emscripten_headers = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch unreachable;
+    const emscripten_headers = try std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" });
     defer b.allocator.free(emscripten_headers);
     lib.addIncludePath(.{ .cwd_relative = emscripten_headers });
     return lib;

--- a/emcc.zig
+++ b/emcc.zig
@@ -46,12 +46,17 @@ pub fn compileForEmscripten(
     // it messes with the build system itself.
 
     // The project is built as a library and linked later.
-    return b.addStaticLibrary(.{
+    const lib = b.addStaticLibrary(.{
         .name = name,
         .root_source_file = b.path(root_source_file),
         .target = target,
         .optimize = optimize,
     });
+
+    const emscripten_headers = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch unreachable;
+    defer b.allocator.free(emscripten_headers);
+    lib.addIncludePath(.{ .cwd_relative = emscripten_headers });
+    return lib;
 }
 
 // Links a set of items together using emscripten.

--- a/project_setup.ps1
+++ b/project_setup.ps1
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) !void {
 
     //web exports are completely separate
     if (target.query.os_tag == .emscripten) {
-        const exe_lib = rlz.emcc.compileForEmscripten(b, "$PROJECT_NAME", "src/main.zig", target, optimize);
+        const exe_lib = try rlz.emcc.compileForEmscripten(b, "$PROJECT_NAME", "src/main.zig", target, optimize);
 
         exe_lib.linkLibrary(raylib_artifact);
         exe_lib.root_module.addImport("raylib", raylib);

--- a/project_setup.sh
+++ b/project_setup.sh
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build) !void {
 
     //web exports are completely separate
     if (target.query.os_tag == .emscripten) {
-        const exe_lib = rlz.emcc.compileForEmscripten(b, "'$PROJECT_NAME'", "src/main.zig", target, optimize);
+        const exe_lib = try rlz.emcc.compileForEmscripten(b, "'$PROJECT_NAME'", "src/main.zig", target, optimize);
 
         exe_lib.linkLibrary(raylib_artifact);
         exe_lib.root_module.addImport("raylib", raylib);


### PR DESCRIPTION
When building for the web, Emscripten automatically links a library that allows the program to communicate with the browser, but the headers need to be manually added through the `build.zig`. This PR updates the `emcc.zig` compile function to automatically add the necessary headers for Emscripten before returning the step.

The Emscripten functions can then be imported using the following snippet:

```zig
const emscripten = if (builtin.os.tag == .emscripten) @cImport(@cInclude("emscripten.h")) else undefined;
```

Unfortunately, I had to update the compile function to return an error because I couldn't think of a way to assemble the path without allocation.

Examples weren't affected. Tested on Windows 11.