### PR TITLE
raylib: add missing fields to Mesh struct

### DIFF
--- a/lib/preludes/raylib-prelude.zig
+++ b/lib/preludes/raylib-prelude.zig
@@ -1381,6 +1381,8 @@ pub const Mesh = extern struct {
     boneWeights: [*c]f32,
     boneMatrices: [*c]Matrix,
     boneCount: c_int,
+    vaoId: c_int,
+    vboId: [*c]c_int,
 
     /// Draw a 3d mesh with material and transform
     pub fn draw(self: Mesh, material: Material, transform: Matrix) void {

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -1381,6 +1381,8 @@ pub const Mesh = extern struct {
     boneWeights: [*c]f32,
     boneMatrices: [*c]Matrix,
     boneCount: c_int,
+    vaoId: c_int,
+    vboId: [*c]c_int,
 
     /// Draw a 3d mesh with material and transform
     pub fn draw(self: Mesh, material: Material, transform: Matrix) void {


### PR DESCRIPTION
Add missing veoId and vboId fields to the Mesh struct. This fixes some crashes when meshes are being manipulated on the Zig side, for example when genMesh* functions are used.