### PR TITLE
Update raylib to 5.6-dev and improved build file

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -276,6 +276,12 @@ pub fn build(b: *std.Build) !void {
             .path = "examples/text/text_format_text.zig",
             .desc = "Renders variables as text",
         },
+        .{
+            .name = "textures_image_loading",
+            .path = "examples/textures/textures_image_loading.zig",
+            .desc = "Image loading and texture creation",
+        },
+
         // .{
         //     .name = "models_loading",
         //     .path = "examples/models/models_loading.zig",

--- a/emcc.zig
+++ b/emcc.zig
@@ -92,7 +92,10 @@ pub fn linkWithEmscripten(
     }
 
     // Create the output directory because emcc can't do it.
-    const mkdir_command = b.addSystemCommand(&[_][]const u8{ "mkdir", "-p", emccOutputDir });
+    const mkdir_command = switch (builtin.os.tag) {
+        .windows => b.addSystemCommand(&.{ "cmd.exe", "/c", "if", "not", "exist", emccOutputDir, "mkdir", emccOutputDir }),
+        else => b.addSystemCommand(&.{ "mkdir", "-p", emccOutputDir }),
+    };
 
     // Actually link everything together.
     const emcc_command = b.addSystemCommand(&[_][]const u8{emcc_run_arg});
@@ -106,6 +109,7 @@ pub fn linkWithEmscripten(
     emcc_command.addArgs(&[_][]const u8{
         "-o",
         emccOutputDir ++ emccOutputFile,
+        "-sUSE_OFFSET_CONVERTER",
         "-sFULL-ES3=1",
         "-sUSE_GLFW=3",
         "-sASYNCIFY",

--- a/examples/textures/textures_image_loading.zig
+++ b/examples/textures/textures_image_loading.zig
@@ -1,0 +1,67 @@
+// raylib-zig (c) Nikolas Wipper 2023
+//
+// raylib-zig [textures] example - image loading
+//
+// Example licensed under an unmodified zlib/libpng license, which is an
+// OSI-certified, BSD-like license that allows static linking with closed
+// source software
+
+const rl = @import("raylib");
+const Color = rl.Color;
+const screenWidth = 800;
+const screenHeight = 450;
+
+//--------------------------------------------------------------------------------------
+// Program entry point
+//--------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+    //Initialization
+    //--------------------------------------------------------------------------------------
+    rl.initWindow(
+        screenWidth,
+        screenHeight,
+        "raylib [textures] example - image loading",
+    );
+
+    // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
+
+    const image = rl.loadImage("logo/logo.png"); // Loaded in CPU memory (RAM)
+    const texture = rl.loadTextureFromImage(image); // Image converted to texture, GPU memory (VRAM)
+    // Once image has been converted to texture and uploaded to VRAM,
+    // it can be unloaded from RAM
+    rl.unloadImage(image);
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------
+    defer rl.unloadTexture(texture); // Texture unloading
+    defer rl.closeWindow(); // Close window and OpenGL context
+    //--------------------------------------------------------------------------------------
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    while (!rl.windowShouldClose()) {
+        // Update
+        //--------------------------------------------------------------------------------------
+        // TODO: Update your variables here
+        //--------------------------------------------------------------------------------------
+
+        // Draw
+        //--------------------------------------------------------------------------------------
+        rl.beginDrawing();
+        rl.clearBackground(Color.white);
+        rl.drawTexture(
+            texture,
+            screenWidth / 2 - @divFloor(texture.width, 2),
+            screenHeight / 2 - @divFloor(texture.height, 2),
+            Color.white,
+        );
+        rl.drawText(
+            "this IS a texture loaded from an image!",
+            300,
+            370,
+            10,
+            Color.gray,
+        );
+        rl.endDrawing();
+        //--------------------------------------------------------------------------------------
+    }
+}


### PR DESCRIPTION
I tried to improve the build system by utilizing the new build.zig from raylib by forwarding the types to this build system.
Also, with updating raylib to 5.6-dev it's now possible to switch the platform with the build system.