### PR TITLE
Add both field for runtime Linux platform detection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,10 +28,7 @@ pub const OpenglVersion = enum {
     gles_3,
 };
 
-pub const LinuxDisplayBackend = enum {
-    X11,
-    Wayland,
-};
+pub const LinuxDisplayBackend = enum { X11, Wayland, Both };
 
 pub const PlatformBackend = enum {
     glfw,


### PR DESCRIPTION
I added a feature to raylib's build.zig like 6 months ago that allows the user to specify "both" for the Linux display platform to allow glfw to use runtime platform detection. I am just adding the "Both" field here as well. 