### PR TITLE
Use GamepadAxis enum for getGamepadAxisMovement instead of c_int

### DIFF
--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -173,6 +173,7 @@ _fix_enums_data = [
     ("flag",        "ConfigFlags",           r"IsWindowState"),
     ("flags",       "Gesture",               r"SetGesturesEnabled"),
     ("button",      "GamepadButton",         r".*GamepadButton.*"),
+    ("axis",        "GamepadAxis",           r".*GamepadAxis.*"),
     ("button",      "MouseButton",           r".*MouseButton.*"),
     ("control",     "GuiControl",            r"Gui.etStyle"),
 #    ("property",    "GuiControlProperty",    r"Gui.etStyle"),

--- a/lib/raylib-ext.zig
+++ b/lib/raylib-ext.zig
@@ -177,7 +177,7 @@ pub extern "c" fn IsGamepadButtonReleased(gamepad: c_int, button: rl.GamepadButt
 pub extern "c" fn IsGamepadButtonUp(gamepad: c_int, button: rl.GamepadButton) bool;
 pub extern "c" fn GetGamepadButtonPressed() rl.GamepadButton;
 pub extern "c" fn GetGamepadAxisCount(gamepad: c_int) c_int;
-pub extern "c" fn GetGamepadAxisMovement(gamepad: c_int, axis: c_int) f32;
+pub extern "c" fn GetGamepadAxisMovement(gamepad: c_int, axis: rl.GamepadAxis) f32;
 pub extern "c" fn SetGamepadMappings(mappings: [*c]const u8) c_int;
 pub extern "c" fn SetGamepadVibration(gamepad: c_int, leftMotor: f32, rightMotor: f32, duration: f32) void;
 pub extern "c" fn IsMouseButtonPressed(button: rl.MouseButton) bool;

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -3156,8 +3156,8 @@ pub fn getGamepadAxisCount(gamepad: i32) i32 {
 }
 
 /// Get axis movement value for a gamepad axis
-pub fn getGamepadAxisMovement(gamepad: i32, axis: i32) f32 {
-    return cdef.GetGamepadAxisMovement(@as(c_int, gamepad), @as(c_int, axis));
+pub fn getGamepadAxisMovement(gamepad: i32, axis: GamepadAxis) f32 {
+    return @as(f32, cdef.GetGamepadAxisMovement(@as(c_int, gamepad), @as(c_int, axis)));
 }
 
 /// Set internal gamepad mappings (SDL_GameControllerDB)

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -3157,7 +3157,7 @@ pub fn getGamepadAxisCount(gamepad: i32) i32 {
 
 /// Get axis movement value for a gamepad axis
 pub fn getGamepadAxisMovement(gamepad: i32, axis: GamepadAxis) f32 {
-    return @as(f32, cdef.GetGamepadAxisMovement(@as(c_int, gamepad), axis));
+    return cdef.GetGamepadAxisMovement(@as(c_int, gamepad), axis);
 }
 
 /// Set internal gamepad mappings (SDL_GameControllerDB)

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -3157,7 +3157,7 @@ pub fn getGamepadAxisCount(gamepad: i32) i32 {
 
 /// Get axis movement value for a gamepad axis
 pub fn getGamepadAxisMovement(gamepad: i32, axis: GamepadAxis) f32 {
-    return @as(f32, cdef.GetGamepadAxisMovement(@as(c_int, gamepad), @as(c_int, axis)));
+    return @as(f32, cdef.GetGamepadAxisMovement(@as(c_int, gamepad), axis));
 }
 
 /// Set internal gamepad mappings (SDL_GameControllerDB)


### PR DESCRIPTION
Added GamepadAxis to the _fix_enums_data in generate_functions.py