### PR TITLE
Fix segault in textures_image_loading

### DIFF
--- a/examples/textures/textures_image_loading.zig
+++ b/examples/textures/textures_image_loading.zig
@@ -33,8 +33,8 @@ pub fn main() anyerror!void {
 
     // De-Initialization
     //--------------------------------------------------------------------------------------
-    defer rl.unloadTexture(texture); // Texture unloading
     defer rl.closeWindow(); // Close window and OpenGL context
+    defer rl.unloadTexture(texture); // Texture unloading
     //--------------------------------------------------------------------------------------
 
     rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second


### PR DESCRIPTION
Window closes before texture is unloaded, causing a segfault when texture tries to unload.