### PR TITLE
Fixing linker error for raygui when building in shared mode.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -116,6 +116,7 @@ fn getRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
         const raygui_dep = b.dependency("raygui", .{
             .target = target,
             .optimize = optimize,
+            .shared = options.shared,
         });
 
         var gen_step = b.addWriteFiles();


### PR DESCRIPTION
Adding 2 flags for when shared mode is enabled and bubbling the array error all the way to the top of build as done in the raysan5/raylib build.zig