### PR TITLE
Port of basic_window_web from raylib

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -228,6 +228,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Creates a basic window with text",
         },
         .{
+            .name = "basic_window_web",
+            .path = "examples/core/basic_window_web.zig",
+            .desc = "Creates a basic window with text (web)",
+        },
+        .{
             .name = "input_keys",
             .path = "examples/core/input_keys.zig",
             .desc = "Simple keyboard input",

--- a/examples/core/basic_window_web.zig
+++ b/examples/core/basic_window_web.zig
@@ -1,0 +1,54 @@
+// A raylib-zig port of https://github.com/raysan5/raylib/blob/master/examples/core/core_basic_window_web.c
+
+const rl = @import("raylib");
+const builtin = @import("builtin");
+
+const c = if (builtin.os.tag == .emscripten) @cImport({
+    @cInclude("emscripten/emscripten.h");
+});
+
+//----------------------------------------------------------------------------------
+// Global Variables Definition
+//----------------------------------------------------------------------------------
+const screenWidth = 800;
+const screenHeight = 450;
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    rl.initWindow(screenWidth, screenHeight, "raylib-zig [core] example - basic window");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    if (builtin.os.tag == .emscripten) {
+        c.emscripten_set_main_loop(@ptrCast(&updateDrawFrame), 0, true);
+    } else {
+        rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+
+        // Main game loop
+        while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+            updateDrawFrame();
+        }
+    }
+}
+
+// Update and Draw one frame
+fn updateDrawFrame() void {
+    // Update
+    //----------------------------------------------------------------------------------
+    // TODO: Update your variables here
+    //----------------------------------------------------------------------------------
+
+    // Draw
+    //----------------------------------------------------------------------------------
+    rl.beginDrawing();
+    defer rl.endDrawing();
+
+    rl.clearBackground(rl.Color.white);
+
+    rl.drawText("Congrats! You created your first window!", 190, 200, 20, rl.Color.light_gray);
+    //----------------------------------------------------------------------------------
+}


### PR DESCRIPTION
This example uses with `emscripten_set_main_loop()` instead of the `while(!rl.windowShouldClose())` loop when targeting emscripten, which allows to reach full speed as per [raylib recommendations](https://github.com/raysan5/raylib/wiki/Working-for-Web-(HTML5)#4-setup-raylib-game-for-web). 

I already saw a huge framerate increase as is, but maybe the `linkWithEmscripten()` function could use a flag to toggle the `-sASYNCIFY` argument which is not needed in this case.