### PR TITLE
Fix the incorrect `.name` property assignment in build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .raylib_zig,
+    .name = "raylib_zig",
     .version = "5.6.0-dev",
     .fingerprint = 0xc4cfa8c610114f28,
     .dependencies = .{


### PR DESCRIPTION
The `.name` property seems to only accept string literals. Building the raylib-zig project with `zig build` is failing as seen below.

![screenshot](https://github.com/user-attachments/assets/64b48e48-4e08-40f5-be22-7625e4c0db17)
