### PR TITLE
Fix exportImageToMemory

### DIFF
--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -122,6 +122,8 @@ def add_namespace_to_type(t: str) -> str:
 def make_return_cast(source_type: str, dest_type: str, inner: str) -> str:
     if source_type == dest_type:
         return inner
+    if "ExportImageToMemory" in inner:
+        return f"{inner}[0..@as(usize, @intCast(fileSize.*))]"
     if source_type in ["[*c]const u8", "[*c]u8"]:
         return f"std.mem.span({inner})"
 

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -1813,7 +1813,38 @@ pub const MaterialMapIndex = enum(c_int) {
     brdf = 10,
 };
 
-pub const ShaderLocationIndex = enum(c_int) { vertex_position = 0, vertex_texcoord01 = 1, vertex_texcoord02 = 2, vertex_normal = 3, vertex_tangent = 4, vertex_color = 5, matrix_mvp = 6, matrix_view = 7, matrix_projection = 8, matrix_model = 9, matrix_normal = 10, vector_view = 11, color_diffuse = 12, color_specular = 13, color_ambient = 14, map_albedo = 15, map_metalness = 16, map_normal = 17, map_roughness = 18, map_occlusion = 19, map_emission = 20, map_height = 21, map_cubemap = 22, map_irradiance = 23, map_prefilter = 24, map_brdf = 25, vertex_boneids = 26, vertex_boneweights = 27, bone_matrices = 28, shader_loc_vertex_instance_tx };
+pub const ShaderLocationIndex = enum(c_int) {
+    vertex_position = 0,
+    vertex_texcoord01 = 1,
+    vertex_texcoord02 = 2,
+    vertex_normal = 3,
+    vertex_tangent = 4,
+    vertex_color = 5,
+    matrix_mvp = 6,
+    matrix_view = 7,
+    matrix_projection = 8,
+    matrix_model = 9,
+    matrix_normal = 10,
+    vector_view = 11,
+    color_diffuse = 12,
+    color_specular = 13,
+    color_ambient = 14,
+    map_albedo = 15,
+    map_metalness = 16,
+    map_normal = 17,
+    map_roughness = 18,
+    map_occlusion = 19,
+    map_emission = 20,
+    map_height = 21,
+    map_cubemap = 22,
+    map_irradiance = 23,
+    map_prefilter = 24,
+    map_brdf = 25,
+    vertex_boneids = 26,
+    vertex_boneweights = 27,
+    bone_matrices = 28,
+    shader_loc_vertex_instance_tx
+};
 
 pub const ShaderUniformDataType = enum(c_int) {
     float = 0,
@@ -2526,6 +2557,7 @@ fn remap(_: *anyopaque, buf: []u8, _: std.mem.Alignment, new_len: usize, _: usiz
         return null;
     }
 }
+
 
 const mem_vtable = std.mem.Allocator.VTable{
     .alloc = alloc,
@@ -3805,9 +3837,8 @@ pub fn exportImage(image: Image, fileName: [:0]const u8) bool {
 }
 
 /// Export image to memory buffer
-pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) []u8 {
-    const ptr = cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize)));
-    return ptr[0..@as(usize, @intCast(fileSize.*))];
+pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) [:0]u8 {
+    return cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize)))[0..@as(usize, @intCast(fileSize.*))];
 }
 
 /// Export image as code file defining an array of bytes, returns true on success

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -1813,38 +1813,7 @@ pub const MaterialMapIndex = enum(c_int) {
     brdf = 10,
 };
 
-pub const ShaderLocationIndex = enum(c_int) {
-    vertex_position = 0,
-    vertex_texcoord01 = 1,
-    vertex_texcoord02 = 2,
-    vertex_normal = 3,
-    vertex_tangent = 4,
-    vertex_color = 5,
-    matrix_mvp = 6,
-    matrix_view = 7,
-    matrix_projection = 8,
-    matrix_model = 9,
-    matrix_normal = 10,
-    vector_view = 11,
-    color_diffuse = 12,
-    color_specular = 13,
-    color_ambient = 14,
-    map_albedo = 15,
-    map_metalness = 16,
-    map_normal = 17,
-    map_roughness = 18,
-    map_occlusion = 19,
-    map_emission = 20,
-    map_height = 21,
-    map_cubemap = 22,
-    map_irradiance = 23,
-    map_prefilter = 24,
-    map_brdf = 25,
-    vertex_boneids = 26,
-    vertex_boneweights = 27,
-    bone_matrices = 28,
-    shader_loc_vertex_instance_tx
-};
+pub const ShaderLocationIndex = enum(c_int) { vertex_position = 0, vertex_texcoord01 = 1, vertex_texcoord02 = 2, vertex_normal = 3, vertex_tangent = 4, vertex_color = 5, matrix_mvp = 6, matrix_view = 7, matrix_projection = 8, matrix_model = 9, matrix_normal = 10, vector_view = 11, color_diffuse = 12, color_specular = 13, color_ambient = 14, map_albedo = 15, map_metalness = 16, map_normal = 17, map_roughness = 18, map_occlusion = 19, map_emission = 20, map_height = 21, map_cubemap = 22, map_irradiance = 23, map_prefilter = 24, map_brdf = 25, vertex_boneids = 26, vertex_boneweights = 27, bone_matrices = 28, shader_loc_vertex_instance_tx };
 
 pub const ShaderUniformDataType = enum(c_int) {
     float = 0,
@@ -2557,7 +2526,6 @@ fn remap(_: *anyopaque, buf: []u8, _: std.mem.Alignment, new_len: usize, _: usiz
         return null;
     }
 }
-
 
 const mem_vtable = std.mem.Allocator.VTable{
     .alloc = alloc,
@@ -3837,8 +3805,9 @@ pub fn exportImage(image: Image, fileName: [:0]const u8) bool {
 }
 
 /// Export image to memory buffer
-pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) [:0]u8 {
-    return std.mem.span(cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize))));
+pub fn exportImageToMemory(image: Image, fileType: [:0]const u8, fileSize: *i32) []u8 {
+    const ptr = cdef.ExportImageToMemory(image, @as([*c]const u8, @ptrCast(fileType)), @as([*c]c_int, @ptrCast(fileSize)));
+    return ptr[0..@as(usize, @intCast(fileSize.*))];
 }
 
 /// Export image as code file defining an array of bytes, returns true on success


### PR DESCRIPTION
Remove `std.mem.span()` which assumes a null terminated array, here it is png data, which is not a null terminated string.

The problem is that std.mem.span() is being used incorrectly here. This function creates a slice that extends until the first null byte (0) it finds, which works fine for null-terminated strings, but is inappropriate for binary data like image files that may contain zero bytes as part of their content.

Although the C function ExportImageToMemory populates the fileSize parameter with the actual size of the buffer (2348196 in your case), the Zig binding isn't using this value to create the slice correctly. Instead, it's treating the binary data as if it were a null-terminated string, which explains why you're getting a length of 8 - there's likely a zero byte at position 8.

The function should be modified to create a slice with the proper length based on the fileSize value rather than relying on std.mem.span(). Something like this would be more appropriate: