### PR TITLE
remove emrun from emcc to avoid the game to keep calling stdio.html

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -316,6 +316,7 @@ pub fn build(b: *std.Build) !void {
             // output file, so it also needs to be linked with emscripten.
             exe_lib.linkLibrary(raylib_artifact);
             const link_step = try emcc.linkWithEmscripten(b, &[_]*std.Build.Step.Compile{ exe_lib, raylib_artifact });
+            link_step.addArg("--emrun");
             link_step.addArg("--embed-file");
             link_step.addArg("resources/");
 

--- a/emcc.zig
+++ b/emcc.zig
@@ -15,9 +15,17 @@ pub fn emscriptenRunStep(b: *std.Build) !*std.Build.Step.Run {
     defer b.allocator.free(emrun_run_arg);
 
     if (b.sysroot == null) {
-        emrun_run_arg = try std.fmt.bufPrint(emrun_run_arg, "{s}", .{emrunExe});
+        emrun_run_arg = try std.fmt.bufPrint(
+            emrun_run_arg,
+            "{s}",
+            .{ emrunExe }
+        );
     } else {
-        emrun_run_arg = try std.fmt.bufPrint(emrun_run_arg, "{s}" ++ std.fs.path.sep_str ++ "{s}", .{ b.sysroot.?, emrunExe });
+        emrun_run_arg = try std.fmt.bufPrint(
+            emrun_run_arg,
+            "{s}" ++ std.fs.path.sep_str ++ "{s}",
+            .{ b.sysroot.?, emrunExe }
+        );
     }
 
     const run_cmd = b.addSystemCommand(&[_][]const u8{ emrun_run_arg, emccOutputDir ++ emccOutputFile });
@@ -75,7 +83,11 @@ pub fn linkWithEmscripten(
     defer b.allocator.free(emcc_run_arg);
 
     if (b.sysroot == null) {
-        emcc_run_arg = try std.fmt.bufPrint(emcc_run_arg, "{s}", .{emccExe});
+        emcc_run_arg = try std.fmt.bufPrint(
+            emcc_run_arg,
+            "{s}",
+            .{ emccExe }
+        );
     } else {
         emcc_run_arg = try std.fmt.bufPrint(
             emcc_run_arg,

--- a/emcc.zig
+++ b/emcc.zig
@@ -15,17 +15,9 @@ pub fn emscriptenRunStep(b: *std.Build) !*std.Build.Step.Run {
     defer b.allocator.free(emrun_run_arg);
 
     if (b.sysroot == null) {
-        emrun_run_arg = try std.fmt.bufPrint(
-            emrun_run_arg,
-            "{s}",
-            .{ emrunExe }
-        );
+        emrun_run_arg = try std.fmt.bufPrint(emrun_run_arg, "{s}", .{emrunExe});
     } else {
-        emrun_run_arg = try std.fmt.bufPrint(
-            emrun_run_arg,
-            "{s}" ++ std.fs.path.sep_str ++ "{s}",
-            .{ b.sysroot.?, emrunExe }
-        );
+        emrun_run_arg = try std.fmt.bufPrint(emrun_run_arg, "{s}" ++ std.fs.path.sep_str ++ "{s}", .{ b.sysroot.?, emrunExe });
     }
 
     const run_cmd = b.addSystemCommand(&[_][]const u8{ emrun_run_arg, emccOutputDir ++ emccOutputFile });
@@ -83,11 +75,7 @@ pub fn linkWithEmscripten(
     defer b.allocator.free(emcc_run_arg);
 
     if (b.sysroot == null) {
-        emcc_run_arg = try std.fmt.bufPrint(
-            emcc_run_arg,
-            "{s}",
-            .{ emccExe }
-        );
+        emcc_run_arg = try std.fmt.bufPrint(emcc_run_arg, "{s}", .{emccExe});
     } else {
         emcc_run_arg = try std.fmt.bufPrint(
             emcc_run_arg,
@@ -120,7 +108,6 @@ pub fn linkWithEmscripten(
         "-sASYNCIFY",
         "-O3",
         "-fsanitize=undefined",
-        "--emrun",
     });
     return emcc_command;
 }

--- a/project_setup.ps1
+++ b/project_setup.ps1
@@ -38,6 +38,7 @@ pub fn build(b: *std.Build) !void {
         // Note that raylib itself is not actually added to the exe_lib output file, so it also needs to be linked with emscripten.
         const link_step = try rlz.emcc.linkWithEmscripten(b, &[_]*std.Build.Step.Compile{ exe_lib, raylib_artifact });
         //this lets your program access files like "resources/my-image.png":
+        link_step.addArg("--emrun");
         link_step.addArg("--embed-file");
         link_step.addArg("resources/");
 

--- a/project_setup.sh
+++ b/project_setup.sh
@@ -39,6 +39,7 @@ pub fn build(b: *std.Build) !void {
         // Note that raylib itself is not actually added to the exe_lib output file, so it also needs to be linked with emscripten.
         const link_step = try rlz.emcc.linkWithEmscripten(b, &[_]*std.Build.Step.Compile{ exe_lib, raylib_artifact });
         //this lets your program access files like "resources/my-image.png":
+        link_step.addArg("--emrun");
         link_step.addArg("--embed-file");
         link_step.addArg("resources/");
 


### PR DESCRIPTION
Suggesting to remove --emrun as it makes the game to Post requests to stdio.html, if the developer needs it it can be added on the `build.zig`.
![image](https://github.com/user-attachments/assets/412813c1-be98-4a04-ac1e-a3810703ad40)
