### PR TITLE
[Emsdk] Fix Touch screen  on wasm by upgrading raylib version.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,7 @@ fn getRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
         .optimize = optimize,
     });
 
-    rl.addRaygui(b, raylib, raygui_dep);
+    rl.addRaygui(b, raylib, raygui_dep, options);
 
     b.installArtifact(raylib);
     return raylib;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .fingerprint = 0xc4cfa8c610114f28,
     .dependencies = .{
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib?ref=master#f5c96302d5623950dccdca31f8dd66d6d633dbd1",
-            .hash = "raylib-5.5.0-whq8uFV0zQA9NXxhpYFZk_yHW6xzg5eKGmOtMJ2DOTdU",
+            .url = "git+https://github.com/raysan5/raylib?ref=master#bdda18656b301303b711785db48ac311655bb3d9",
+            .hash = "raylib-5.5.0-whq8uExcNgQBBys4-PIIEqPuWO-MpfOJkwiM4Q1nLXVN",
         },
         .raygui = .{
             .url = "git+https://github.com/raysan5/raygui#1536ae35c7b42d863135f4181fd2a225e531f68b",


### PR DESCRIPTION
This upgrade is related to this PR: https://github.com/raysan5/raylib/pull/5011

> In `v3.1.62` of `Emscripten`, they changed their bool type from int to bool, so the size of the `EmscriptenTouch` Structs were different from the current major version of the `Emscripten`, It was provoking memory corruption, getting completely wrong values from `GetTouchPosition`.
> 
> My issue was with the TouchScreen but it solves as well any issue that the struct is created on `Emscripten` side.
> 
> Issue:
> 
> * `Emscripten` trying to create a struct size: 1552
> * `C` receiving a struct size: 1696

