### PR TITLE
prepare build to run on zig 15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,7 +51,7 @@ fn getModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
     if (b.modules.contains("raylib")) {
         return b.modules.get("raylib").?;
     }
-    return b.addModule("raylib", .{
+    return b.createModule(.{
         .root_source_file = b.path("lib/raylib.zig"),
         .target = target,
         .optimize = optimize,
@@ -61,7 +61,7 @@ fn getModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
 const gui = struct {
     fn getModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Module {
         const raylib = this.getModule(b, target, optimize);
-        return b.addModule("raygui", .{
+        return b.createModule(.{
             .root_source_file = b.path("lib/raygui.zig"),
             .imports = &.{.{ .name = "raylib-zig", .module = raylib }},
             .target = target,
@@ -293,16 +293,12 @@ pub fn build(b: *std.Build) !void {
     };
 
     const raylib_test = b.addTest(.{
-        .root_source_file = b.path("lib/raylib.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = raylib,
     });
     raylib_test.linkLibC();
 
     const raygui_test = b.addTest(.{
-        .root_source_file = b.path("lib/raygui.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = raygui,
     });
     raygui_test.root_module.addImport("raylib-zig", raylib);
     raygui_test.linkLibC();
@@ -336,9 +332,11 @@ pub fn build(b: *std.Build) !void {
         } else {
             const exe = b.addExecutable(.{
                 .name = ex.name,
-                .root_source_file = b.path(ex.path),
-                .optimize = optimize,
-                .target = target,
+                .root_module = b.createModule(.{
+                    .root_source_file = b.path(ex.path),
+                    .target = target,
+                    .optimize = optimize,
+                }),
             });
             exe.linkLibrary(raylib_artifact);
             exe.root_module.addImport("raylib", raylib);

--- a/emcc.zig
+++ b/emcc.zig
@@ -40,7 +40,7 @@ pub fn compileForEmscripten(
     // The project is built as a library and linked later.
     const lib = b.addLibrary(.{
         .name = name,
-        .linkage = .dynamic,
+        .linkage = .static,
         .root_module = b.createModule(.{
             .root_source_file = b.path(root_source_file),
             .target = target,

--- a/emcc.zig
+++ b/emcc.zig
@@ -15,17 +15,9 @@ pub fn emscriptenRunStep(b: *std.Build) !*std.Build.Step.Run {
     defer b.allocator.free(emrun_run_arg);
 
     if (b.sysroot == null) {
-        emrun_run_arg = try std.fmt.bufPrint(
-            emrun_run_arg,
-            "{s}",
-            .{ emrunExe }
-        );
+        emrun_run_arg = try std.fmt.bufPrint(emrun_run_arg, "{s}", .{emrunExe});
     } else {
-        emrun_run_arg = try std.fmt.bufPrint(
-            emrun_run_arg,
-            "{s}" ++ std.fs.path.sep_str ++ "{s}",
-            .{ b.sysroot.?, emrunExe }
-        );
+        emrun_run_arg = try std.fmt.bufPrint(emrun_run_arg, "{s}" ++ std.fs.path.sep_str ++ "{s}", .{ b.sysroot.?, emrunExe });
     }
 
     const run_cmd = b.addSystemCommand(&[_][]const u8{ emrun_run_arg, emccOutputDir ++ emccOutputFile });
@@ -38,7 +30,7 @@ pub fn compileForEmscripten(
     name: []const u8,
     root_source_file: []const u8,
     target: std.Build.ResolvedTarget,
-    optimize: std.builtin.Mode,
+    optimize: std.builtin.OptimizeMode,
 ) !*std.Build.Step.Compile {
     // TODO: It might be a good idea to create a custom compile step, that does
     // both the compile to static library and the link with emcc by overidding
@@ -46,11 +38,14 @@ pub fn compileForEmscripten(
     // it messes with the build system itself.
 
     // The project is built as a library and linked later.
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = name,
-        .root_source_file = b.path(root_source_file),
-        .target = target,
-        .optimize = optimize,
+        .linkage = .dynamic,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path(root_source_file),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const emscripten_headers = try std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" });
@@ -83,11 +78,7 @@ pub fn linkWithEmscripten(
     defer b.allocator.free(emcc_run_arg);
 
     if (b.sysroot == null) {
-        emcc_run_arg = try std.fmt.bufPrint(
-            emcc_run_arg,
-            "{s}",
-            .{ emccExe }
-        );
+        emcc_run_arg = try std.fmt.bufPrint(emcc_run_arg, "{s}", .{emccExe});
     } else {
         emcc_run_arg = try std.fmt.bufPrint(
             emcc_run_arg,


### PR DESCRIPTION
Swapping some functions to be able to run on zig v15 (It does not break zig v14)

`addModule` to `createModule`
`std.builtin.Mode` to `std.builtin.OptimizeMode`
`addStaticLibrary` to `addLibrary` with `linkage = .static` (for web)


Ps: This PR needs a raylib update (as it was fixed there already).