### PR TITLE
[examples] Add box collisions and add  `unloadModelAnimations` for bone socket

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -368,6 +368,11 @@ pub fn build(b: *std.Build) !void {
             .path = "examples/models/models_bone_socket.zig",
             .desc = "Bone socket",
         },
+        .{
+            .name = "models_box_collisions",
+            .path = "examples/models/models_box_collisions.zig",
+            .desc = "Box collisions",
+        },
         // .{
         //     .name = "shaders_basic_lighting",
         //     .path = "examples/shaders/shaders_basic_lighting.zig",

--- a/examples/models/models_bone_socket.zig
+++ b/examples/models/models_bone_socket.zig
@@ -41,6 +41,7 @@ pub fn main() anyerror!void {
     var animCurrentFrame: i32 = 0;
     const modelAnimations = try rl.loadModelAnimations("examples/models/resources/models/gltf/greenman.glb");
     const animsCount = modelAnimations.len;
+    defer rl.unloadModelAnimations(modelAnimations);
 
     // indices of bones for sockets
     var boneSocketIndex: [BONE_SOCKETS]usize = undefined;

--- a/examples/models/models_box_collisions.zig
+++ b/examples/models/models_box_collisions.zig
@@ -1,0 +1,119 @@
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    const screenWidth: i32 = 800;
+    const screenHeight: i32 = 450;
+
+    rl.initWindow(screenWidth, screenHeight, "raylib [models] example - box collisions");
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------
+    defer rl.closeWindow(); // Close window and OpenGL context
+    //--------------------------------------------------------------------------------------
+
+    // Define the camera to look into our 3d world
+    const camera: rl.Camera = .{
+        .position = .{ .x = 0.0, .y = 10.0, .z = 10.0 },
+        .target = .{ .x = 0.0, .y = 0.0, .z = 0.0 },
+        .up = .{ .x = 0.0, .y = 1.0, .z = 0.0 },
+        .fovy = 45.0,
+        .projection = .perspective,
+    };
+
+    var playerPosition: rl.Vector3 = .{ .x = 0.0, .y = 1.0, .z = 2.0 };
+    const playerSize: rl.Vector3 = .{ .x = 1.0, .y = 2.0, .z = 1.0 };
+    var playerColor: rl.Color = .green;
+
+    const enemyBoxPos: rl.Vector3 = .{ .x = -4.0, .y = 1.0, .z = 0.0 };
+    const enemyBoxSize: rl.Vector3 = .{ .x = 2.0, .y = 2.0, .z = 2.0 };
+
+    const enemySpherePos: rl.Vector3 = .{ .x = 4.0, .y = 0.0, .z = 0.0 };
+    const enemySphereSize: f32 = 1.5;
+
+    var collision: bool = false;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+
+    while (!rl.windowShouldClose()) {
+        // Update
+        //----------------------------------------------------------------------------------
+
+        // Move player
+        if (rl.isKeyDown(.right)) playerPosition.x += 0.2 else if (rl.isKeyDown(.left)) playerPosition.x -= 0.2 else if (rl.isKeyDown(.down)) playerPosition.z += 0.2 else if (rl.isKeyDown(.up)) playerPosition.z -= 0.2;
+
+        collision = false;
+
+        // Check collisions player vs enemy-box
+        if (rl.checkCollisionBoxes(.{
+            .min = .{
+                .x = playerPosition.x - playerSize.x / 2,
+                .y = playerPosition.y - playerSize.y / 2,
+                .z = playerPosition.z - playerSize.z / 2,
+            },
+            .max = .{
+                .x = playerPosition.x + playerSize.x / 2,
+                .y = playerPosition.y + playerSize.y / 2,
+                .z = playerPosition.z + playerSize.z / 2,
+            },
+        }, .{
+            .min = .{
+                .x = enemyBoxPos.x - enemyBoxSize.x / 2,
+                .y = enemyBoxPos.y - enemyBoxSize.y / 2,
+                .z = enemyBoxPos.z - enemyBoxSize.z / 2,
+            },
+            .max = .{
+                .x = enemyBoxPos.x + enemyBoxSize.x / 2,
+                .y = enemyBoxPos.y + enemyBoxSize.y / 2,
+                .z = enemyBoxPos.z + enemyBoxSize.z / 2,
+            },
+        })) collision = true;
+
+        // Check collisions player vs enemy-sphere
+        if (rl.checkCollisionBoxSphere(.{
+            .min = .{
+                .x = playerPosition.x - playerSize.x / 2,
+                .y = playerPosition.y - playerSize.y / 2,
+                .z = playerPosition.z - playerSize.z / 2,
+            },
+            .max = .{
+                .x = playerPosition.x + playerSize.x / 2,
+                .y = playerPosition.y + playerSize.y / 2,
+                .z = playerPosition.z + playerSize.z / 2,
+            },
+        }, enemySpherePos, enemySphereSize)) collision = true;
+
+        if (collision) playerColor = .red else playerColor = .green;
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.ray_white);
+        {
+            rl.beginMode3D(camera);
+            defer rl.endMode3D();
+
+            // Draw enemy-box
+            rl.drawCube(enemyBoxPos, enemyBoxSize.x, enemyBoxSize.y, enemyBoxSize.z, .gray);
+            rl.drawCubeWires(enemyBoxPos, enemyBoxSize.x, enemyBoxSize.y, enemyBoxSize.z, .dark_gray);
+
+            // Draw enemy-sphere
+            rl.drawSphere(enemySpherePos, enemySphereSize, .gray);
+            rl.drawSphereWires(enemySpherePos, enemySphereSize, 16, 16, .dark_gray);
+
+            // Draw player
+            rl.drawCubeV(playerPosition, playerSize, playerColor);
+
+            rl.drawGrid(10, 1.0); // Draw a grid
+
+        }
+
+        rl.drawText("Move player with arrow keys to collide", 220, 40, 20, .gray);
+
+        rl.drawFPS(10, 10);
+
+        //----------------------------------------------------------------------------------
+    }
+}


### PR DESCRIPTION
Adding box collisions for https://github.com/raylib-zig/raylib-zig/issues/200
Extra: _Fixing unload ModelAnimations for bone socket_

<img width="1146" height="661" alt="image" src="https://github.com/user-attachments/assets/f6fa9c0c-132e-4dc0-a7d5-4973dd02842b" />

