### PR TITLE
Add placeholder entry to ControlProperty

### DIFF
--- a/lib/preludes/raygui-prelude.zig
+++ b/lib/preludes/raygui-prelude.zig
@@ -81,6 +81,7 @@ pub const ControlProperty = enum(c_int) {
     border_width,
     text_padding,
     text_alignment,
+    _,
 };
 
 pub const DefaultProperty = enum(c_int) {


### PR DESCRIPTION
This makes it so we can safely use `@enumFromInt(@intFromEnum(...))` where we have properties from specific controls not encapsulated by the values in `ControlProperty` (i.e.: `rg.ScrollBarProperty.scroll_slider_size`).

However, this is a bit of a hack. Let me know if it's better to include all types in the union.