### PR TITLE
make .zero and .one able to be comptime-known

### DIFF
--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -57,12 +57,12 @@ pub const Vector2 = extern struct {
 
     /// Vector with components value 0.0
     pub fn zero() Vector2 {
-        return math.vector2Zero();
+        return Vector2{ .x = 0.0, .y = 0.0 };
     }
 
     /// Vector with components value 1.0
     pub fn one() Vector2 {
-        return math.vector2One();
+        return Vector2{ .x = 1.0, .y = 1.0 };
     }
 
     /// Add two vectors (v1 + v2)
@@ -225,12 +225,12 @@ pub const Vector3 = extern struct {
 
     // Vector with components value 0.0
     pub fn zero() Vector3 {
-        return math.vector3Zero();
+        return Vector3{ .x = 0.0, .y = 0.0, .z = 0.0};
     }
 
     /// Vector with components value 1.0
     pub fn one() Vector3 {
-        return math.vector3One();
+        return Vector3{ .x = 1.0, .y = 1.0, .z = 1.0};
     }
 
     /// Add two vectors
@@ -443,12 +443,12 @@ pub const Vector4 = extern struct {
 
     /// Vector with components value 0.0
     pub fn zero() Vector4 {
-        return math.vector4Zero();
+        return Vector4{.x = 0.0, .y = 0.0, .z = 0.0, .w = 0.0};
     }
 
     /// Vector with components value 1.0
     pub fn one() Vector4 {
-        return math.vector4One();
+        return Vector4{.x = 1.0, .y = 1.0, .z = 1.0, .w = 1.0};
     }
 
     /// Add two vectors


### PR DESCRIPTION
It's just so you can use Vector.zero and Vector.one as default values for a struct's fields.