### PR TITLE
chore: bump raylib to master

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .fingerprint = 0xc4cfa8c610114f28,
     .dependencies = .{
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib#8ada37d9671682f420a2be1f1afd4b06173b81ad",
-            .hash = "raylib-5.6.0-dev-whq8uCg2ywTzCiX3VEP9RuCMXR6_VnDBmkj8GjL_p5QN",
+            .url = "git+https://github.com/raysan5/raylib#51bdaa34fa2f84063d643d999e44f54d52cc38d1",
+            .hash = "raylib-5.6.0-dev-whq8uNQMDQVVlVyFhb0djbgPzO2rljTg_sYMBZBvb83d",
         },
         .raygui = .{
             .url = "git+https://github.com/raysan5/raygui#9cdfec460b43a17264af3c181c46f62bf107ac17",


### PR DESCRIPTION
This is done to resolve a missing symbol error related to `DrawLineDashed`. Oddly enough the bindings had the method mapped however using it will result in an error.

```bash
# before
find .zig-cache -name "libraylib.a" -exec nm -gU {} + | grep DrawLineDashed

# after
find .zig-cache -name "libraylib.a" -exec nm -gU {} + | grep DrawLineDashed
0000000000000c7c T _DrawLineDashed
```