### PR TITLE
Fix: Readme, deprecated function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const raylib_artifact = raylib_dep.artifact("raylib"); // raylib C library
 Now add the modules and artifact to your target as you would normally:
 
 ```zig
-exe.linkLibrary(raylib_artifact);
+exe.root_module.linkLibrary(raylib_artifact);
 exe.root_module.addImport("raylib", raylib);
 exe.root_module.addImport("raygui", raygui);
 ```


### PR DESCRIPTION
In the [setting up raylib-zig](https://github.com/raylib-zig/raylib-zig?tab=readme-ov-file#building-and-using) part, I noticed the use of the deprecated `linkLibrary(compile: *Compile, library: *Compile)` where it was used as 
`exe.linkLibrary("raylib");` 
instead of 
`exe.root_module.linkLibrary("raylib");`
(which is correctly used for the 2 modules written just below)