### PR TITLE
Pass Options.config through to raylib's build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,7 @@ fn getRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
         .opengl_version = options.opengl_version,
         .android_api_version = options.android_api_version,
         .android_ndk = options.android_ndk,
+        .config = options.config,
     });
 
     const raylib = raylib_dep.artifact("raylib");


### PR DESCRIPTION
All other options of `rl.Options` are passed through to raylib build, but `config` is not. This makes it impossible to pass special defines to raylib's build.