### PR TITLE
Make KeyboardKey a non-exhaustive enum to avoid crashes with unmapped keys.

### DIFF
--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -1819,6 +1819,7 @@ pub const KeyboardKey = enum(c_int) {
     //menu = 82,
     volume_up = 24,
     volume_down = 25,
+    _,
 };
 
 pub const MouseButton = enum(c_int) {


### PR DESCRIPTION
Fix: #310