### PR TITLE
Integrate code generation into build.zig

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -1,0 +1,37 @@
+name: Check Generated Files
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-generated-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Verify generated files are up to date
+        run: |
+          set -euo pipefail
+
+          rm -rf /tmp/lib
+          cp -r lib /tmp/lib
+
+          rm -f lib/*.h
+          rm -f lib/r*.zig
+
+          zig build code
+
+          if ! diff -ru lib /tmp/lib; then
+            echo ""
+            echo "Generated files are out of date."
+            echo "Run: zig build code"
+            exit 1
+          fi

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -27,11 +27,11 @@ jobs:
           rm -f lib/*.h
           rm -f lib/r*.zig
 
-          zig build code
+          zig build binding
 
           if ! diff -ru lib /tmp/lib; then
             echo ""
             echo "Generated files are out of date."
-            echo "Run: zig build code"
+            echo "Run: zig build binding"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ however, are created manually and should only be updated in their respective pre
  - `lib/preludes/rlgl-prelude.zig` for rlgl types
  - `lib/preludes/raygui-prelude.zig` for raygui types
 
-Before any commit you make, you should always run `generate_functions.py` to ensure your changes are persistent
+Before any commit you make, you should always run `zig build code` to ensure your changes are persistent
 throughout other updates.
 
 ## Updates to the build files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ however, are created manually and should only be updated in their respective pre
  - `lib/preludes/rlgl-prelude.zig` for rlgl types
  - `lib/preludes/raygui-prelude.zig` for raygui types
 
-Before any commit you make, you should always run `zig build code` to ensure your changes are persistent
+Before any commit you make, you should always run `zig build binding` to ensure your changes are persistent
 throughout other updates.
 
 ## Updates to the build files

--- a/build.zig
+++ b/build.zig
@@ -16,17 +16,6 @@ const Program = struct {
     desc: []const u8,
 };
 
-const Code = struct {
-    header_dependency_file: std.Build.LazyPath,
-    header_file: []const u8,
-    prelude_file: []const u8,
-    ext_prelude_file: []const u8,
-    output_file: []const u8,
-    ext_output_file: []const u8,
-    prefix: []const u8,
-    skip_after: ?[]const u8 = null,
-};
-
 fn getModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Module {
     if (b.modules.contains("raylib")) {
         return b.modules.get("raylib").?;
@@ -539,47 +528,6 @@ pub fn build(b: *std.Build) !void {
         // },
     };
 
-    const codes = [_]Code{
-        .{
-            .header_dependency_file = raylib_headers.get("raylib.h").?,
-            .header_file = "lib/raylib.h",
-            .prelude_file = "lib/preludes/raylib-prelude.zig",
-            .ext_prelude_file = "lib/preludes/raylib-ext-prelude.zig",
-            .output_file = "lib/raylib.zig",
-            .ext_output_file = "lib/raylib-ext.zig",
-            .prefix = "RLAPI ",
-        },
-        .{
-            .header_dependency_file = raylib_headers.get("raymath.h").?,
-            .header_file = "lib/raymath.h",
-            .prelude_file = "lib/preludes/raymath-prelude.zig",
-            .ext_prelude_file = "lib/preludes/raymath-ext-prelude.zig",
-            .output_file = "lib/raymath.zig",
-            .ext_output_file = "lib/raymath-ext.zig",
-            .prefix = "RMAPI ",
-        },
-        .{
-            .header_dependency_file = raylib_headers.get("rlgl.h").?,
-            .header_file = "lib/rlgl.h",
-            .prelude_file = "lib/preludes/rlgl-prelude.zig",
-            .ext_prelude_file = "lib/preludes/rlgl-ext-prelude.zig",
-            .output_file = "lib/rlgl.zig",
-            .ext_output_file = "lib/rlgl-ext.zig",
-            .prefix = "RLAPI ",
-            .skip_after = "#if defined(RLGL_IMPLEMENTATION)",
-        },
-        .{
-            .header_dependency_file = raylib_headers.get("raygui.h").?,
-            .header_file = "lib/raygui.h",
-            .prelude_file = "lib/preludes/raygui-prelude.zig",
-            .ext_prelude_file = "lib/preludes/raygui-ext-prelude.zig",
-            .output_file = "lib/raygui.zig",
-            .ext_output_file = "lib/raygui-ext.zig",
-            .prefix = "RAYGUIAPI ",
-            .skip_after = "#if defined(RAYGUI_IMPLEMENTATION)",
-        },
-    };
-
     const raylib_test = b.addTest(.{
         .root_module = raylib,
     });
@@ -595,46 +543,20 @@ pub fn build(b: *std.Build) !void {
     test_step.dependOn(&raylib_test.step);
     test_step.dependOn(&raygui_test.step);
 
-    const generate_code_step = b.step("code", "Generate the code");
+    const generate_binding_step = b.step("binding", "Generate the binding");
 
-    for (codes) |code| {
-        const usf_dependency = b.addUpdateSourceFiles();
-        usf_dependency.addCopyFileToSource(code.header_dependency_file, code.header_file);
+    const usf_dependency = b.addUpdateSourceFiles();
+    usf_dependency.addCopyFileToSource(raylib_headers.get("raylib.h").?, "lib/raylib.h");
+    usf_dependency.addCopyFileToSource(raylib_headers.get("raymath.h").?, "lib/raymath.h");
+    usf_dependency.addCopyFileToSource(raylib_headers.get("rlgl.h").?, "lib/rlgl.h");
+    usf_dependency.addCopyFileToSource(raylib_headers.get("raygui.h").?, "lib/raygui.h");
 
-        const code_step = b.addSystemCommand(&.{"python"});
-        code_step.addFileArg(b.path("lib/generate_functions.py"));
+    const bind_step = b.addSystemCommand(&.{"python3"});
+    bind_step.addFileArg(b.path("lib/generate_functions.py"));
+    bind_step.setCwd(b.path("lib"));
+    bind_step.step.dependOn(&usf_dependency.step);
 
-        code_step.addArg("--header-file");
-        code_step.addFileArg(b.path(code.header_file));
-
-        code_step.addArg("--prelude-file");
-        code_step.addFileArg(b.path(code.prelude_file));
-
-        code_step.addArg("--ext-prelude-file");
-        code_step.addFileArg(b.path(code.ext_prelude_file));
-
-        code_step.addArg("--output-file");
-        const output_file = code_step.addOutputFileArg(code.output_file);
-
-        code_step.addArg("--ext-output-file");
-        const ext_output_file = code_step.addOutputFileArg(code.ext_output_file);
-
-        code_step.addArg("--prefix");
-        code_step.addArg(code.prefix);
-
-        if (code.skip_after) |skip_after| {
-            code_step.addArg("--skip-after");
-            code_step.addArg(skip_after);
-        }
-
-        code_step.step.dependOn(&usf_dependency.step);
-
-        const usf = b.addUpdateSourceFiles();
-        usf.addCopyFileToSource(output_file, code.output_file);
-        usf.addCopyFileToSource(ext_output_file, code.ext_output_file);
-
-        generate_code_step.dependOn(&usf.step);
-    }
+    generate_binding_step.dependOn(&bind_step.step);
 
     const examples_step = b.step("examples", "Builds all the examples");
 

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,17 @@ const Program = struct {
     desc: []const u8,
 };
 
+const Code = struct {
+    header_dependency_file: std.Build.LazyPath,
+    header_file: []const u8,
+    prelude_file: []const u8,
+    ext_prelude_file: []const u8,
+    output_file: []const u8,
+    ext_output_file: []const u8,
+    prefix: []const u8,
+    skip_after: ?[]const u8 = null,
+};
+
 fn getModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Module {
     if (b.modules.contains("raylib")) {
         return b.modules.get("raylib").?;
@@ -65,6 +76,13 @@ pub fn build(b: *std.Build) !void {
     });
 
     const raylib_artifact = raylib_dep.artifact("raylib");
+
+    var raylib_headers: std.StringHashMap(std.Build.LazyPath) = .init(b.allocator);
+    defer raylib_headers.deinit();
+
+    for (raylib_artifact.installed_headers.items) |item| {
+        try raylib_headers.put(item.file.dest_rel_path, item.file.source);
+    }
 
     b.installArtifact(raylib_artifact);
 
@@ -521,6 +539,47 @@ pub fn build(b: *std.Build) !void {
         // },
     };
 
+    const codes = [_]Code{
+        .{
+            .header_dependency_file = raylib_headers.get("raylib.h").?,
+            .header_file = "lib/raylib.h",
+            .prelude_file = "lib/preludes/raylib-prelude.zig",
+            .ext_prelude_file = "lib/preludes/raylib-ext-prelude.zig",
+            .output_file = "lib/raylib.zig",
+            .ext_output_file = "lib/raylib-ext.zig",
+            .prefix = "RLAPI ",
+        },
+        .{
+            .header_dependency_file = raylib_headers.get("raymath.h").?,
+            .header_file = "lib/raymath.h",
+            .prelude_file = "lib/preludes/raymath-prelude.zig",
+            .ext_prelude_file = "lib/preludes/raymath-ext-prelude.zig",
+            .output_file = "lib/raymath.zig",
+            .ext_output_file = "lib/raymath-ext.zig",
+            .prefix = "RMAPI ",
+        },
+        .{
+            .header_dependency_file = raylib_headers.get("rlgl.h").?,
+            .header_file = "lib/rlgl.h",
+            .prelude_file = "lib/preludes/rlgl-prelude.zig",
+            .ext_prelude_file = "lib/preludes/rlgl-ext-prelude.zig",
+            .output_file = "lib/rlgl.zig",
+            .ext_output_file = "lib/rlgl-ext.zig",
+            .prefix = "RLAPI ",
+            .skip_after = "#if defined(RLGL_IMPLEMENTATION)",
+        },
+        .{
+            .header_dependency_file = raylib_headers.get("raygui.h").?,
+            .header_file = "lib/raygui.h",
+            .prelude_file = "lib/preludes/raygui-prelude.zig",
+            .ext_prelude_file = "lib/preludes/raygui-ext-prelude.zig",
+            .output_file = "lib/raygui.zig",
+            .ext_output_file = "lib/raygui-ext.zig",
+            .prefix = "RAYGUIAPI ",
+            .skip_after = "#if defined(RAYGUI_IMPLEMENTATION)",
+        },
+    };
+
     const raylib_test = b.addTest(.{
         .root_module = raylib,
     });
@@ -535,6 +594,47 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Check for library compilation errors");
     test_step.dependOn(&raylib_test.step);
     test_step.dependOn(&raygui_test.step);
+
+    const generate_code_step = b.step("code", "Generate the code");
+
+    for (codes) |code| {
+        const usf_dependency = b.addUpdateSourceFiles();
+        usf_dependency.addCopyFileToSource(code.header_dependency_file, code.header_file);
+
+        const code_step = b.addSystemCommand(&.{"python"});
+        code_step.addFileArg(b.path("lib/generate_functions.py"));
+
+        code_step.addArg("--header-file");
+        code_step.addFileArg(b.path(code.header_file));
+
+        code_step.addArg("--prelude-file");
+        code_step.addFileArg(b.path(code.prelude_file));
+
+        code_step.addArg("--ext-prelude-file");
+        code_step.addFileArg(b.path(code.ext_prelude_file));
+
+        code_step.addArg("--output-file");
+        const output_file = code_step.addOutputFileArg(code.output_file);
+
+        code_step.addArg("--ext-output-file");
+        const ext_output_file = code_step.addOutputFileArg(code.ext_output_file);
+
+        code_step.addArg("--prefix");
+        code_step.addArg(code.prefix);
+
+        if (code.skip_after) |skip_after| {
+            code_step.addArg("--skip-after");
+            code_step.addArg(skip_after);
+        }
+
+        code_step.step.dependOn(&usf_dependency.step);
+
+        const usf = b.addUpdateSourceFiles();
+        usf.addCopyFileToSource(output_file, code.output_file);
+        usf.addCopyFileToSource(ext_output_file, code.ext_output_file);
+
+        generate_code_step.dependOn(&usf.step);
+    }
 
     const examples_step = b.step("examples", "Builds all the examples");
 

--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import re
-import argparse
 
 """
 Automatic utility for generating raylib function headers.
@@ -490,24 +489,37 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Automatic utility for generating raylib function headers.")
-
-    parser.add_argument("--header-file", required=True)
-    parser.add_argument("--prelude-file", required=True)
-    parser.add_argument("--ext-prelude-file", required=True)
-    parser.add_argument("--output-file", required=True)
-    parser.add_argument("--ext-output-file", required=True)
-    parser.add_argument("--prefix", required=True)
-    parser.add_argument("--skip-after", default="#/never\\#")
-
-    args = parser.parse_args()
-
     parse_header(
-        args.header_file,
-        args.output_file,
-        args.ext_output_file,
-        args.prefix,
-        args.prelude_file,
-        args.ext_prelude_file,
-        args.skip_after,
+        "raylib.h",
+        "raylib.zig",
+        "raylib-ext.zig",
+        "RLAPI ",
+        "preludes/raylib-prelude.zig",
+        "preludes/raylib-ext-prelude.zig"
+    )
+    parse_header(
+        "raymath.h",
+        "raymath.zig",
+        "raymath-ext.zig",
+        "RMAPI ",
+        "preludes/raymath-prelude.zig",
+        "preludes/raymath-ext-prelude.zig"
+    )
+    parse_header(
+        "rlgl.h",
+        "rlgl.zig",
+        "rlgl-ext.zig",
+        "RLAPI ",
+        "preludes/rlgl-prelude.zig",
+        "preludes/rlgl-ext-prelude.zig",
+        "#if defined(RLGL_IMPLEMENTATION)\n"
+    )
+    parse_header(
+        "raygui.h",
+        "raygui.zig",
+        "raygui-ext.zig",
+        "RAYGUIAPI ",
+        "preludes/raygui-prelude.zig",
+        "preludes/raygui-ext-prelude.zig",
+        "#if defined(RAYGUI_IMPLEMENTATION)\n"
     )

--- a/lib/generate_functions.py
+++ b/lib/generate_functions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import re
+import argparse
 
 """
 Automatic utility for generating raylib function headers.
@@ -489,37 +490,24 @@ def parse_header(header_name: str, output_file: str, ext_file: str, prefix: str,
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Automatic utility for generating raylib function headers.")
+
+    parser.add_argument("--header-file", required=True)
+    parser.add_argument("--prelude-file", required=True)
+    parser.add_argument("--ext-prelude-file", required=True)
+    parser.add_argument("--output-file", required=True)
+    parser.add_argument("--ext-output-file", required=True)
+    parser.add_argument("--prefix", required=True)
+    parser.add_argument("--skip-after", default="#/never\\#")
+
+    args = parser.parse_args()
+
     parse_header(
-        "raylib.h",
-        "raylib.zig",
-        "raylib-ext.zig",
-        "RLAPI ",
-        "preludes/raylib-prelude.zig",
-        "preludes/raylib-ext-prelude.zig"
-    )
-    parse_header(
-        "raymath.h",
-        "raymath.zig",
-        "raymath-ext.zig",
-        "RMAPI ",
-        "preludes/raymath-prelude.zig",
-        "preludes/raymath-ext-prelude.zig"
-    )
-    parse_header(
-        "rlgl.h",
-        "rlgl.zig",
-        "rlgl-ext.zig",
-        "RLAPI ",
-        "preludes/rlgl-prelude.zig",
-        "preludes/rlgl-ext-prelude.zig",
-        "#if defined(RLGL_IMPLEMENTATION)\n"
-    )
-    parse_header(
-        "raygui.h",
-        "raygui.zig",
-        "raygui-ext.zig",
-        "RAYGUIAPI ",
-        "preludes/raygui-prelude.zig",
-        "preludes/raygui-ext-prelude.zig",
-        "#if defined(RAYGUI_IMPLEMENTATION)\n"
+        args.header_file,
+        args.output_file,
+        args.ext_output_file,
+        args.prefix,
+        args.prelude_file,
+        args.ext_prelude_file,
+        args.skip_after,
     )


### PR DESCRIPTION
Replaces the previously rejected PR #328

## This PR:

- adds code generation to `build.zig` so now you should run `zig build code` to generate the code
- code generation now copies the raylib header files from the raylib dependency to ensure it's updated, helping when the raylib version is updated
- adds github action to verify that generated files are up to date

So, now even if you delete the c headers and generated zig files the `zig build code` will recreate everything.

And, if someone makes a PR without running the code generation the validation will fail.